### PR TITLE
Using Console.* class instead of Debug.* for debug prints

### DIFF
--- a/src/Operation.cs
+++ b/src/Operation.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Debug = CitizenFX.Core.Debug;
 
 namespace MySQLAsync
 {
@@ -14,7 +15,7 @@ namespace MySQLAsync
 
         internal string Query = "";
         internal IDictionary<string, object> Parameters = null;
-        internal bool Debug = false;
+        internal bool debug = false;
         internal uint ThreadedId = 0;
 
         public Operation(string connectionString)
@@ -28,7 +29,7 @@ namespace MySQLAsync
             {
                 query = Query;
                 parameters = Parameters;
-                debug = Debug;
+                debug = this.debug;
             }
 
             TResult result = default(TResult);
@@ -54,7 +55,7 @@ namespace MySQLAsync
 
                         if (debug)
                         {
-                            Console.WriteLine(string.Format("[{0}] [C: {1}ms, Q: {2}ms, R: {3}ms] {4}", "MySQL", ConnectionTime, QueryTime, stopwatch.ElapsedMilliseconds, QueryToString(query, parameters)));
+                            Debug.WriteLine(string.Format("[{0}] [C: {1}ms, Q: {2}ms, R: {3}ms] {4}", "MySQL", ConnectionTime, QueryTime, stopwatch.ElapsedMilliseconds, QueryToString(query, parameters)));
                         }
                     }
                 }
@@ -68,15 +69,15 @@ namespace MySQLAsync
                     throw;
                 }
 
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), firstException.Message));
+                Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), firstException.Message));
             }
             catch (MySqlException mysqlException)
             {
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), mysqlException.Message));
+                Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), mysqlException.Message));
             }
             catch (Exception exception)
             {
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An critical error happens on MySQL for query \"{1}\": {2} {3}\n", "MySQL", QueryToString(query, parameters), exception.Message, exception.StackTrace));
+                Debug.Write(string.Format("[ERROR] [{0}] An critical error happens on MySQL for query \"{1}\": {2} {3}\n", "MySQL", QueryToString(query, parameters), exception.Message, exception.StackTrace));
             }
 
             return result;
@@ -107,7 +108,7 @@ namespace MySQLAsync
 
                         if (debug)
                         {
-                            Console.WriteLine(string.Format("[{0}] [C: {1}ms, Q: {2}ms, R: {3}ms] {4}", "MySQL", ConnectionTime, QueryTime, stopwatch.ElapsedMilliseconds, QueryToString(query, parameters)));
+                            Debug.WriteLine(string.Format("[{0}] [C: {1}ms, Q: {2}ms, R: {3}ms] {4}", "MySQL", ConnectionTime, QueryTime, stopwatch.ElapsedMilliseconds, QueryToString(query, parameters)));
                         }
 
                         callback.Invoke(result);
@@ -123,19 +124,19 @@ namespace MySQLAsync
                     throw aggregateException;
                 }
 
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), firstException.Message));
+                Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), firstException.Message));
             }
             catch (MySqlException mysqlException)
             {
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), mysqlException.Message));
+                Debug.Write(string.Format("[ERROR] [{0}] An error happens on MySQL for query \"{1}\": {2}\n", "MySQL", QueryToString(query, parameters), mysqlException.Message));
             }
             catch (ArgumentNullException)
             {
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] Check the error above, an error happens when executing the callback from the query : \"{1}\"\n", "MySQL", QueryToString(query, parameters)));
+                Debug.Write(string.Format("[ERROR] [{0}] Check the error above, an error happens when executing the callback from the query : \"{1}\"\n", "MySQL", QueryToString(query, parameters)));
             }
             catch (Exception exception)
             {
-                CitizenFX.Core.Debug.Write(string.Format("[ERROR] [{0}] An critical error happens on MySQL for query \"{1}\": {2} {3}\n", "MySQL", QueryToString(query, parameters), exception.Message, exception.StackTrace));
+                Debug.Write(string.Format("[ERROR] [{0}] An critical error happens on MySQL for query \"{1}\": {2} {3}\n", "MySQL", QueryToString(query, parameters), exception.Message, exception.StackTrace));
             }
         }
 
@@ -143,7 +144,7 @@ namespace MySQLAsync
         {
             Query = query;
             Parameters = parameters;
-            Debug = debug;
+            this.debug = debug;
             MySQLThread mysqlAsync = MySQLThread.GetInstance();
             ThreadedId = mysqlAsync.NextId;
             mysqlAsync.queryCollection.TryAdd(this);

--- a/src/Operation.cs
+++ b/src/Operation.cs
@@ -13,8 +13,8 @@ namespace MySQLAsync
     {
         internal string ConnectionString;
 
-        internal string Query = "";
-        internal IDictionary<string, object> Parameters = null;
+        internal string query = "";
+        internal IDictionary<string, object> parameters = null;
         internal bool debug = false;
         internal uint ThreadedId = 0;
 
@@ -27,9 +27,9 @@ namespace MySQLAsync
         {
             if (string.IsNullOrEmpty(query))
             {
-                query = Query;
-                parameters = Parameters;
-                debug = this.debug;
+                this.query = query;
+                this.parameters = parameters;
+                this.debug = debug;
             }
 
             TResult result = default(TResult);
@@ -142,8 +142,8 @@ namespace MySQLAsync
 
         public async Task<TResult> ExecuteThreaded(string query, IDictionary<string, object> parameters, bool debug = false)
         {
-            Query = query;
-            Parameters = parameters;
+            this.query = query;
+            this.parameters = parameters;
             this.debug = debug;
             MySQLThread mysqlAsync = MySQLThread.GetInstance();
             ThreadedId = mysqlAsync.NextId;


### PR DESCRIPTION
Looks like the debug prints were using Console.* class, thus causing I18N errors in the server console.

Also removed the namespace prefixes and renamed debug boolean to lowercase debug, to prevent a naming collision with Debug.* from Citizen.Core.