### PR TITLE
Fixes the issue with scalar executing. 

### DIFF
--- a/mysql-async.js
+++ b/mysql-async.js
@@ -5247,7 +5247,7 @@ global.on('onServerResourceStart', (resourcename) => {
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
 
-        if(global.GetConvar('mysql_keep_alive', false)){
+        if(global.GetConvar('mysql_keep_alive', false) === 'true'){
             console.log('[MySQL] Enabling keep alive queries')
             keepAlive();
         }

--- a/mysql-async.js
+++ b/mysql-async.js
@@ -5246,11 +5246,18 @@ global.on('onServerResourceStart', (resourcename) => {
         pool = mysql.createPool(config);
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
+        keepAlive();
     }
     if (isReady) {
         global.emit('MySQLReady'); // avoid ESX bugs
     }
 });
+
+function keepAlive(){
+    execute({ sql: 'SHOW TABLES', typeCast }, 'keepAlive').then((result) => {
+        setTimeout(keepAlive, 10000);
+    });
+}
 
 
 /***/ }),

--- a/mysql-async.js
+++ b/mysql-async.js
@@ -5246,7 +5246,11 @@ global.on('onServerResourceStart', (resourcename) => {
         pool = mysql.createPool(config);
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
-        keepAlive();
+
+        if(global.GetConvar('mysql_keep_alive', false)){
+            console.log('[MySQL] Enabling keep alive queries')
+            keepAlive();
+        }
     }
     if (isReady) {
         global.emit('MySQLReady'); // avoid ESX bugs

--- a/mysql-async.js
+++ b/mysql-async.js
@@ -5247,7 +5247,7 @@ global.on('onServerResourceStart', (resourcename) => {
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
 
-        if(global.GetConvar('mysql_keep_alive', false) === 'true'){
+        if(global.GetConvar('mysql_keep_alive', 'false') === 'true'){
             console.log('[MySQL] Enabling keep alive queries')
             keepAlive();
         }

--- a/mysql-async.js
+++ b/mysql-async.js
@@ -194,6 +194,7 @@ var Util           = __webpack_require__(0);
 var EventEmitter   = __webpack_require__(4).EventEmitter;
 var Packets        = __webpack_require__(2);
 var ErrorConstants = __webpack_require__(64);
+var Timer          = __webpack_require__(65);
 
 // istanbul ignore next: Node.js < 0.10 not covered
 var listenerCount = EventEmitter.listenerCount
@@ -217,13 +218,7 @@ function Sequence(options, callback) {
   this._callSite = null;
   this._ended    = false;
   this._timeout  = options.timeout;
-
-  // For Timers
-  this._idleNext    = null;
-  this._idlePrev    = null;
-  this._idleStart   = null;
-  this._idleTimeout = -1;
-  this._repeat      = null;
+  this._timer    = new Timer(this);
 }
 
 Sequence.determinePacket = function(byte) {
@@ -363,7 +358,7 @@ module.exports = require("events");
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(10);
+var pna = __webpack_require__(10);
 /*</replacement>*/
 
 /*<replacement>*/
@@ -387,10 +382,13 @@ var Writable = __webpack_require__(23);
 
 util.inherits(Duplex, Readable);
 
-var keys = objectKeys(Writable.prototype);
-for (var v = 0; v < keys.length; v++) {
-  var method = keys[v];
-  if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+{
+  // avoid scope creep, the keys array can then be collected
+  var keys = objectKeys(Writable.prototype);
+  for (var v = 0; v < keys.length; v++) {
+    var method = keys[v];
+    if (!Duplex.prototype[method]) Duplex.prototype[method] = Writable.prototype[method];
+  }
 }
 
 function Duplex(options) {
@@ -409,6 +407,16 @@ function Duplex(options) {
   this.once('end', onend);
 }
 
+Object.defineProperty(Duplex.prototype, 'writableHighWaterMark', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function () {
+    return this._writableState.highWaterMark;
+  }
+});
+
 // the no-half-open enforcer
 function onend() {
   // if we allow half-open state, or if the writable side ended,
@@ -417,7 +425,7 @@ function onend() {
 
   // no more data can be written.
   // But allow more writes to happen in this tick.
-  processNextTick(onEndNT, this);
+  pna.nextTick(onEndNT, this);
 }
 
 function onEndNT(self) {
@@ -449,14 +457,8 @@ Duplex.prototype._destroy = function (err, cb) {
   this.push(null);
   this.end();
 
-  processNextTick(cb, err);
+  pna.nextTick(cb, err);
 };
-
-function forEach(xs, f) {
-  for (var i = 0, l = xs.length; i < l; i++) {
-    f(xs[i], i);
-  }
-}
 
 /***/ }),
 /* 6 */
@@ -580,7 +582,7 @@ try {
   if (typeof util.inherits !== 'function') throw '';
   module.exports = util.inherits;
 } catch (e) {
-  module.exports = __webpack_require__(72);
+  module.exports = __webpack_require__(74);
 }
 
 
@@ -612,28 +614,16 @@ function Connection(options) {
   this.threadId       = null;
 }
 
-function bindToCurrentDomain(callback) {
-  if (!callback) {
-    return undefined;
-  }
-
-  var domain = process.domain;
-
-  return domain
-    ? domain.bind(callback)
-    : callback;
-}
-
 Connection.createQuery = function createQuery(sql, values, callback) {
   if (sql instanceof Query) {
     return sql;
   }
 
-  var cb      = bindToCurrentDomain(callback);
+  var cb      = wrapCallbackInDomain(null, callback);
   var options = {};
 
   if (typeof sql === 'function') {
-    cb = bindToCurrentDomain(sql);
+    cb = wrapCallbackInDomain(null, sql);
     return new Query(options, cb);
   }
 
@@ -643,7 +633,7 @@ Connection.createQuery = function createQuery(sql, values, callback) {
     }
 
     if (typeof values === 'function') {
-      cb = bindToCurrentDomain(values);
+      cb = wrapCallbackInDomain(null, values);
     } else if (values !== undefined) {
       options.values = values;
     }
@@ -655,7 +645,7 @@ Connection.createQuery = function createQuery(sql, values, callback) {
   options.values = values;
 
   if (typeof values === 'function') {
-    cb = bindToCurrentDomain(values);
+    cb = wrapCallbackInDomain(null, values);
     options.values = undefined;
   }
 
@@ -689,19 +679,20 @@ Connection.prototype.connect = function connect(options, callback) {
     this._protocol.on('data', function(data) {
       connection._socket.write(data);
     });
-    this._socket.on('data', function(data) {
+    this._socket.on('data', wrapToDomain(connection, function (data) {
       connection._protocol.write(data);
-    });
+    }));
     this._protocol.on('end', function() {
       connection._socket.end();
     });
-    this._socket.on('end', function() {
+    this._socket.on('end', wrapToDomain(connection, function () {
       connection._protocol.end();
-    });
+    }));
 
     this._socket.on('error', this._handleNetworkError.bind(this));
     this._socket.on('connect', this._handleProtocolConnect.bind(this));
     this._protocol.on('handshake', this._handleProtocolHandshake.bind(this));
+    this._protocol.on('initialize', this._handleProtocolInitialize.bind(this));
     this._protocol.on('unhandledError', this._handleProtocolError.bind(this));
     this._protocol.on('drain', this._handleProtocolDrain.bind(this));
     this._protocol.on('end', this._handleProtocolEnd.bind(this));
@@ -717,7 +708,7 @@ Connection.prototype.connect = function connect(options, callback) {
     }
   }
 
-  this._protocol.handshake(options, bindToCurrentDomain(callback));
+  this._protocol.handshake(options, wrapCallbackInDomain(this, callback));
 };
 
 Connection.prototype.changeUser = function changeUser(options, callback) {
@@ -739,7 +730,7 @@ Connection.prototype.changeUser = function changeUser(options, callback) {
     timeout       : options.timeout,
     charsetNumber : charsetNumber,
     currentConfig : this.config
-  }, bindToCurrentDomain(callback));
+  }, wrapCallbackInDomain(this, callback));
 };
 
 Connection.prototype.beginTransaction = function beginTransaction(options, callback) {
@@ -793,6 +784,10 @@ Connection.prototype.query = function query(sql, values, cb) {
     query.sql = this.format(query.sql, query.values);
   }
 
+  if (query._callback) {
+    query._callback = wrapCallbackInDomain(this, query._callback);
+  }
+
   this._implyConnect();
 
   return this._protocol._enqueue(query);
@@ -805,7 +800,7 @@ Connection.prototype.ping = function ping(options, callback) {
   }
 
   this._implyConnect();
-  this._protocol.ping(options, bindToCurrentDomain(callback));
+  this._protocol.ping(options, wrapCallbackInDomain(this, callback));
 };
 
 Connection.prototype.statistics = function statistics(options, callback) {
@@ -815,7 +810,7 @@ Connection.prototype.statistics = function statistics(options, callback) {
   }
 
   this._implyConnect();
-  this._protocol.stats(options, bindToCurrentDomain(callback));
+  this._protocol.stats(options, wrapCallbackInDomain(this, callback));
 };
 
 Connection.prototype.end = function end(options, callback) {
@@ -836,7 +831,7 @@ Connection.prototype.end = function end(options, callback) {
   }
 
   this._implyConnect();
-  this._protocol.quit(opts, bindToCurrentDomain(cb));
+  this._protocol.quit(opts, wrapCallbackInDomain(this, cb));
 };
 
 Connection.prototype.destroy = function() {
@@ -874,52 +869,52 @@ Connection.prototype.format = function(sql, values) {
 if (tls.TLSSocket) {
   // 0.11+ environment
   Connection.prototype._startTLS = function _startTLS(onSecure) {
-    var connection    = this;
-    var secureContext = tls.createSecureContext({
-      ca         : this.config.ssl.ca,
-      cert       : this.config.ssl.cert,
-      ciphers    : this.config.ssl.ciphers,
-      key        : this.config.ssl.key,
-      passphrase : this.config.ssl.passphrase
-    });
+    var connection = this;
 
-    // "unpipe"
-    this._socket.removeAllListeners('data');
-    this._protocol.removeAllListeners('data');
-
-    // socket <-> encrypted
-    var rejectUnauthorized = this.config.ssl.rejectUnauthorized;
-    var secureEstablished  = false;
-    var secureSocket       = new tls.TLSSocket(this._socket, {
-      rejectUnauthorized : rejectUnauthorized,
-      requestCert        : true,
-      secureContext      : secureContext,
-      isServer           : false
-    });
-
-    // error handler for secure socket
-    secureSocket.on('_tlsError', function(err) {
-      if (secureEstablished) {
-        connection._handleNetworkError(err);
-      } else {
+    createSecureContext(this.config, function (err, secureContext) {
+      if (err) {
         onSecure(err);
+        return;
       }
+
+      // "unpipe"
+      connection._socket.removeAllListeners('data');
+      connection._protocol.removeAllListeners('data');
+
+      // socket <-> encrypted
+      var rejectUnauthorized = connection.config.ssl.rejectUnauthorized;
+      var secureEstablished  = false;
+      var secureSocket       = new tls.TLSSocket(connection._socket, {
+        rejectUnauthorized : rejectUnauthorized,
+        requestCert        : true,
+        secureContext      : secureContext,
+        isServer           : false
+      });
+
+      // error handler for secure socket
+      secureSocket.on('_tlsError', function(err) {
+        if (secureEstablished) {
+          connection._handleNetworkError(err);
+        } else {
+          onSecure(err);
+        }
+      });
+
+      // cleartext <-> protocol
+      secureSocket.pipe(connection._protocol);
+      connection._protocol.on('data', function(data) {
+        secureSocket.write(data);
+      });
+
+      secureSocket.on('secure', function() {
+        secureEstablished = true;
+
+        onSecure(rejectUnauthorized ? this.ssl.verifyError() : null);
+      });
+
+      // start TLS communications
+      secureSocket._start();
     });
-
-    // cleartext <-> protocol
-    secureSocket.pipe(this._protocol);
-    this._protocol.on('data', function(data) {
-      secureSocket.write(data);
-    });
-
-    secureSocket.on('secure', function() {
-      secureEstablished = true;
-
-      onSecure(rejectUnauthorized ? this.ssl.verifyError() : null);
-    });
-
-    // start TLS communications
-    secureSocket._start();
   };
 } else {
   // pre-0.11 environment
@@ -1032,8 +1027,11 @@ Connection.prototype._handleProtocolConnect = function() {
   this.emit('connect');
 };
 
-Connection.prototype._handleProtocolHandshake = function _handleProtocolHandshake(packet) {
-  this.state    = 'authenticated';
+Connection.prototype._handleProtocolHandshake = function _handleProtocolHandshake() {
+  this.state = 'authenticated';
+};
+
+Connection.prototype._handleProtocolInitialize = function _handleProtocolInitialize(packet) {
   this.threadId = packet.threadId;
 };
 
@@ -1051,6 +1049,75 @@ Connection.prototype._implyConnect = function() {
     this.connect();
   }
 };
+
+function createSecureContext (config, cb) {
+  var context = null;
+  var error   = null;
+
+  try {
+    context = tls.createSecureContext({
+      ca         : config.ssl.ca,
+      cert       : config.ssl.cert,
+      ciphers    : config.ssl.ciphers,
+      key        : config.ssl.key,
+      passphrase : config.ssl.passphrase
+    });
+  } catch (err) {
+    error = err;
+  }
+
+  cb(error, context);
+}
+
+function unwrapFromDomain(fn) {
+  return function () {
+    var domains = [];
+    var ret;
+
+    while (process.domain) {
+      domains.shift(process.domain);
+      process.domain.exit();
+    }
+
+    try {
+      ret = fn.apply(this, arguments);
+    } finally {
+      for (var i = 0; i < domains.length; i++) {
+        domains[i].enter();
+      }
+    }
+
+    return ret;
+  };
+}
+
+function wrapCallbackInDomain(ee, fn) {
+  if (typeof fn !== 'function' || fn.domain) {
+    return fn;
+  }
+
+  var domain = process.domain;
+
+  if (domain) {
+    return domain.bind(fn);
+  } else if (ee) {
+    return unwrapFromDomain(wrapToDomain(ee, fn));
+  } else {
+    return fn;
+  }
+}
+
+function wrapToDomain(ee, fn) {
+  return function () {
+    if (Events.usingDomains && ee.domain) {
+      ee.domain.enter();
+      fn.apply(this, arguments);
+      ee.domain.exit();
+    } else {
+      fn.apply(this, arguments);
+    }
+  };
+}
 
 
 /***/ }),
@@ -1095,9 +1162,9 @@ exports.CLIENT_REMEMBER_OPTIONS       = 2147483648;
 if (!process.version ||
     process.version.indexOf('v0.') === 0 ||
     process.version.indexOf('v1.') === 0 && process.version.indexOf('v1.8.') !== 0) {
-  module.exports = nextTick;
+  module.exports = { nextTick: nextTick };
 } else {
-  module.exports = process.nextTick;
+  module.exports = process
 }
 
 function nextTick(fn, arg1, arg2, arg3) {
@@ -1133,6 +1200,7 @@ function nextTick(fn, arg1, arg2, arg3) {
     });
   }
 }
+
 
 
 /***/ }),
@@ -1346,39 +1414,78 @@ ConnectionConfig.parseUrl = function(url) {
 /* 12 */
 /***/ (function(module, exports) {
 
-// Manually extracted from mysql-5.7.9/include/mysql.h.pp
-// some more info here: http://dev.mysql.com/doc/refman/5.5/en/c-api-prepared-statement-type-codes.html
-exports.DECIMAL     = 0x00; // aka DECIMAL (http://dev.mysql.com/doc/refman/5.0/en/precision-math-decimal-changes.html)
-exports.TINY        = 0x01; // aka TINYINT, 1 byte
-exports.SHORT       = 0x02; // aka SMALLINT, 2 bytes
-exports.LONG        = 0x03; // aka INT, 4 bytes
-exports.FLOAT       = 0x04; // aka FLOAT, 4-8 bytes
-exports.DOUBLE      = 0x05; // aka DOUBLE, 8 bytes
-exports.NULL        = 0x06; // NULL (used for prepared statements, I think)
-exports.TIMESTAMP   = 0x07; // aka TIMESTAMP
-exports.LONGLONG    = 0x08; // aka BIGINT, 8 bytes
-exports.INT24       = 0x09; // aka MEDIUMINT, 3 bytes
-exports.DATE        = 0x0a; // aka DATE
-exports.TIME        = 0x0b; // aka TIME
-exports.DATETIME    = 0x0c; // aka DATETIME
-exports.YEAR        = 0x0d; // aka YEAR, 1 byte (don't ask)
-exports.NEWDATE     = 0x0e; // aka ?
-exports.VARCHAR     = 0x0f; // aka VARCHAR (?)
-exports.BIT         = 0x10; // aka BIT, 1-8 byte
-exports.TIMESTAMP2  = 0x11; // aka TIMESTAMP with fractional seconds
-exports.DATETIME2   = 0x12; // aka DATETIME with fractional seconds
-exports.TIME2       = 0x13; // aka TIME with fractional seconds
-exports.JSON        = 0xf5; // aka JSON
-exports.NEWDECIMAL  = 0xf6; // aka DECIMAL
-exports.ENUM        = 0xf7; // aka ENUM
-exports.SET         = 0xf8; // aka SET
-exports.TINY_BLOB   = 0xf9; // aka TINYBLOB, TINYTEXT
-exports.MEDIUM_BLOB = 0xfa; // aka MEDIUMBLOB, MEDIUMTEXT
-exports.LONG_BLOB   = 0xfb; // aka LONGBLOG, LONGTEXT
-exports.BLOB        = 0xfc; // aka BLOB, TEXT
-exports.VAR_STRING  = 0xfd; // aka VARCHAR, VARBINARY
-exports.STRING      = 0xfe; // aka CHAR, BINARY
-exports.GEOMETRY    = 0xff; // aka GEOMETRY
+/**
+ * MySQL type constants
+ *
+ * Extracted from version 5.7.19
+ *
+ * !! Generated by generate-type-constants.js, do not modify by hand !!
+ */
+
+exports.DECIMAL     = 0;
+exports.TINY        = 1;
+exports.SHORT       = 2;
+exports.LONG        = 3;
+exports.FLOAT       = 4;
+exports.DOUBLE      = 5;
+exports.NULL        = 6;
+exports.TIMESTAMP   = 7;
+exports.LONGLONG    = 8;
+exports.INT24       = 9;
+exports.DATE        = 10;
+exports.TIME        = 11;
+exports.DATETIME    = 12;
+exports.YEAR        = 13;
+exports.NEWDATE     = 14;
+exports.VARCHAR     = 15;
+exports.BIT         = 16;
+exports.TIMESTAMP2  = 17;
+exports.DATETIME2   = 18;
+exports.TIME2       = 19;
+exports.JSON        = 245;
+exports.NEWDECIMAL  = 246;
+exports.ENUM        = 247;
+exports.SET         = 248;
+exports.TINY_BLOB   = 249;
+exports.MEDIUM_BLOB = 250;
+exports.LONG_BLOB   = 251;
+exports.BLOB        = 252;
+exports.VAR_STRING  = 253;
+exports.STRING      = 254;
+exports.GEOMETRY    = 255;
+
+// Lookup-by-number table
+exports[0]   = 'DECIMAL';
+exports[1]   = 'TINY';
+exports[2]   = 'SHORT';
+exports[3]   = 'LONG';
+exports[4]   = 'FLOAT';
+exports[5]   = 'DOUBLE';
+exports[6]   = 'NULL';
+exports[7]   = 'TIMESTAMP';
+exports[8]   = 'LONGLONG';
+exports[9]   = 'INT24';
+exports[10]  = 'DATE';
+exports[11]  = 'TIME';
+exports[12]  = 'DATETIME';
+exports[13]  = 'YEAR';
+exports[14]  = 'NEWDATE';
+exports[15]  = 'VARCHAR';
+exports[16]  = 'BIT';
+exports[17]  = 'TIMESTAMP2';
+exports[18]  = 'DATETIME2';
+exports[19]  = 'TIME2';
+exports[245] = 'JSON';
+exports[246] = 'NEWDECIMAL';
+exports[247] = 'ENUM';
+exports[248] = 'SET';
+exports[249] = 'TINY_BLOB';
+exports[250] = 'MEDIUM_BLOB';
+exports[251] = 'LONG_BLOB';
+exports[252] = 'BLOB';
+exports[253] = 'VAR_STRING';
+exports[254] = 'STRING';
+exports[255] = 'GEOMETRY';
 
 
 /***/ }),
@@ -1532,7 +1639,7 @@ function loadClass(className) {
       Class = __webpack_require__(27);
       break;
     case 'PoolCluster':
-      Class = __webpack_require__(83);
+      Class = __webpack_require__(84);
       break;
     case 'PoolConfig':
       Class = __webpack_require__(28);
@@ -1843,7 +1950,7 @@ function Field(options) {
   this.db     = options.packet.db;
   this.table  = options.packet.table;
   this.name   = options.packet.name;
-  this.type   = typeToString(options.packet.type);
+  this.type   = Types[options.packet.type];
   this.length = options.packet.length;
 }
 
@@ -1859,14 +1966,6 @@ Field.prototype.geometry = function () {
   return this.parser.parseGeometryValue();
 };
 
-function typeToString(t) {
-  for (var k in Types) {
-    if (Types[k] === t) return k;
-  }
-
-  return undefined;
-}
-
 
 /***/ }),
 /* 18 */
@@ -1875,6 +1974,18 @@ function typeToString(t) {
 var Buffer = __webpack_require__(1).Buffer;
 var Crypto = __webpack_require__(15);
 var Auth   = exports;
+
+function auth(name, data, options) {
+  options = options || {};
+
+  switch (name) {
+    case 'mysql_native_password':
+      return Auth.token(options.password, data.slice(0, 20));
+    default:
+      return undefined;
+  }
+}
+Auth.auth = auth;
 
 function sha1(msg) {
   var hash = Crypto.createHash('sha1');
@@ -1909,10 +2020,10 @@ Auth.token = function(password, scramble) {
 // This is a port of sql/password.c:hash_password which needs to be used for
 // pre-4.1 passwords.
 Auth.hashPassword = function(password) {
-  var nr = [0x5030, 0x5735],
-      add = 7,
-      nr2 = [0x1234, 0x5671],
-      result = Buffer.alloc(8);
+  var nr     = [0x5030, 0x5735];
+  var add    = 7;
+  var nr2    = [0x1234, 0x5671];
+  var result = Buffer.alloc(8);
 
   if (typeof password === 'string'){
     password = Buffer.from(password);
@@ -1960,12 +2071,16 @@ Auth.myRnd = function(r){
 };
 
 Auth.scramble323 = function(message, password) {
-  var to = Buffer.allocUnsafe(8),
-      hashPass = this.hashPassword(password),
-      hashMessage = this.hashPassword(message.slice(0, 8)),
-      seed1 = this.int32Read(hashPass, 0) ^ this.int32Read(hashMessage, 0),
-      seed2 = this.int32Read(hashPass, 4) ^ this.int32Read(hashMessage, 4),
-      r = this.randomInit(seed1, seed2);
+  if (!password) {
+    return Buffer.alloc(0);
+  }
+
+  var to          = Buffer.allocUnsafe(8);
+  var hashPass    = this.hashPassword(password);
+  var hashMessage = this.hashPassword(message.slice(0, 8));
+  var seed1       = this.int32Read(hashPass, 0) ^ this.int32Read(hashMessage, 0);
+  var seed2       = this.int32Read(hashPass, 4) ^ this.int32Read(hashMessage, 4);
+  var r           = this.randomInit(seed1, seed2);
 
   for (var i = 0; i < 8; i++){
     to[i] = Math.floor(this.myRnd(r) * 31) + 64;
@@ -1984,8 +2099,8 @@ Auth.xor32 = function(a, b){
 };
 
 Auth.add32 = function(a, b){
-  var w1 = a[1] + b[1],
-      w2 = a[0] + b[0] + ((w1 & 0xFFFF0000) >> 16);
+  var w1 = a[1] + b[1];
+  var w2 = a[0] + b[0] + ((w1 & 0xFFFF0000) >> 16);
 
   return [w2 & 0xFFFF, w1 & 0xFFFF];
 };
@@ -1993,8 +2108,8 @@ Auth.add32 = function(a, b){
 Auth.mul32 = function(a, b){
   // based on this example of multiplying 32b ints using 16b
   // http://www.dsprelated.com/showmessage/89790/1.php
-  var w1 = a[1] * b[1],
-      w2 = (((a[1] * b[1]) >> 16) & 0xFFFF) + ((a[0] * b[1]) & 0xFFFF) + (a[1] * b[0] & 0xFFFF);
+  var w1 = a[1] * b[1];
+  var w2 = (((a[1] * b[1]) >> 16) & 0xFFFF) + ((a[0] * b[1]) & 0xFFFF) + (a[1] * b[0] & 0xFFFF);
 
   return [w2 & 0xFFFF, w1 & 0xFFFF];
 };
@@ -2005,8 +2120,8 @@ Auth.and32 = function(a, b){
 
 Auth.shl32 = function(a, b){
   // assume b is 16 or less
-  var w1 = a[1] << b,
-      w2 = (a[0] << b) | ((w1 & 0xFFFF0000) >> 16);
+  var w1 = a[1] << b;
+  var w2 = (a[0] << b) | ((w1 & 0xFFFF0000) >> 16);
 
   return [w2 & 0xFFFF, w1 & 0xFFFF];
 };
@@ -2033,10 +2148,10 @@ Auth.int32Read = function(buffer, offset){
 var Sequence     = __webpack_require__(3);
 var Util         = __webpack_require__(0);
 var Packets      = __webpack_require__(2);
-var ResultSet    = __webpack_require__(67);
-var ServerStatus = __webpack_require__(68);
-var fs           = __webpack_require__(69);
-var Readable     = __webpack_require__(70);
+var ResultSet    = __webpack_require__(69);
+var ServerStatus = __webpack_require__(70);
+var fs           = __webpack_require__(71);
+var Readable     = __webpack_require__(72);
 
 module.exports = Query;
 Util.inherits(Query, Sequence);
@@ -2212,12 +2327,12 @@ Query.prototype._sendLocalDataFile = function(path) {
 };
 
 Query.prototype.stream = function(options) {
-  var self = this,
-      stream;
+  var self = this;
 
   options = options || {};
   options.objectMode = true;
-  stream = new Readable(options);
+
+  var stream = new Readable(options);
 
   stream._read = function() {
     self._connection && self._connection.resume();
@@ -2280,13 +2395,13 @@ Query.prototype.stream = function(options) {
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(10);
+var pna = __webpack_require__(10);
 /*</replacement>*/
 
 module.exports = Readable;
 
 /*<replacement>*/
-var isArray = __webpack_require__(71);
+var isArray = __webpack_require__(73);
 /*</replacement>*/
 
 /*<replacement>*/
@@ -2307,9 +2422,8 @@ var EElistenerCount = function (emitter, type) {
 var Stream = __webpack_require__(21);
 /*</replacement>*/
 
-// TODO(bmeurer): Change this back to const once hole checks are
-// properly optimized away early in Ignition+TurboFan.
 /*<replacement>*/
+
 var Buffer = __webpack_require__(1).Buffer;
 var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
@@ -2318,6 +2432,7 @@ function _uint8ArrayToBuffer(chunk) {
 function _isUint8Array(obj) {
   return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
+
 /*</replacement>*/
 
 /*<replacement>*/
@@ -2335,7 +2450,7 @@ if (debugUtil && debugUtil.debuglog) {
 }
 /*</replacement>*/
 
-var BufferList = __webpack_require__(73);
+var BufferList = __webpack_require__(75);
 var destroyImpl = __webpack_require__(22);
 var StringDecoder;
 
@@ -2346,15 +2461,13 @@ var kProxyEvents = ['error', 'close', 'destroy', 'pause', 'resume'];
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
   // event emitter implementation with them.
-  if (typeof emitter.prependListener === 'function') {
-    return emitter.prependListener(event, fn);
-  } else {
-    // This is a hack to make sure that our error handler is attached before any
-    // userland ones.  NEVER DO THIS. This is here only because this code needs
-    // to continue to work with older versions of Node.js that do not include
-    // the prependListener() method. The goal is to eventually remove this hack.
-    if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
-  }
+  if (typeof emitter.prependListener === 'function') return emitter.prependListener(event, fn);
+
+  // This is a hack to make sure that our error handler is attached before any
+  // userland ones.  NEVER DO THIS. This is here only because this code needs
+  // to continue to work with older versions of Node.js that do not include
+  // the prependListener() method. The goal is to eventually remove this hack.
+  if (!emitter._events || !emitter._events[event]) emitter.on(event, fn);else if (isArray(emitter._events[event])) emitter._events[event].unshift(fn);else emitter._events[event] = [fn, emitter._events[event]];
 }
 
 function ReadableState(options, stream) {
@@ -2362,17 +2475,26 @@ function ReadableState(options, stream) {
 
   options = options || {};
 
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream.
+  // These options can be provided separately as readableXXX and writableXXX.
+  var isDuplex = stream instanceof Duplex;
+
   // object stream flag. Used to make read(n) ignore n and to
   // make all the buffer merging and length checks go away
   this.objectMode = !!options.objectMode;
 
-  if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
+  if (isDuplex) this.objectMode = this.objectMode || !!options.readableObjectMode;
 
   // the point at which it stops calling _read() to fill the buffer
   // Note: 0 is a valid value, means "don't call _read preemptively ever"
   var hwm = options.highWaterMark;
+  var readableHwm = options.readableHighWaterMark;
   var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+
+  if (hwm || hwm === 0) this.highWaterMark = hwm;else if (isDuplex && (readableHwm || readableHwm === 0)) this.highWaterMark = readableHwm;else this.highWaterMark = defaultHwm;
 
   // cast to ints.
   this.highWaterMark = Math.floor(this.highWaterMark);
@@ -2745,7 +2867,7 @@ function emitReadable(stream) {
   if (!state.emittedReadable) {
     debug('emitReadable', state.flowing);
     state.emittedReadable = true;
-    if (state.sync) processNextTick(emitReadable_, stream);else emitReadable_(stream);
+    if (state.sync) pna.nextTick(emitReadable_, stream);else emitReadable_(stream);
   }
 }
 
@@ -2764,7 +2886,7 @@ function emitReadable_(stream) {
 function maybeReadMore(stream, state) {
   if (!state.readingMore) {
     state.readingMore = true;
-    processNextTick(maybeReadMore_, stream, state);
+    pna.nextTick(maybeReadMore_, stream, state);
   }
 }
 
@@ -2809,7 +2931,7 @@ Readable.prototype.pipe = function (dest, pipeOpts) {
   var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
 
   var endFn = doEnd ? onend : unpipe;
-  if (state.endEmitted) processNextTick(endFn);else src.once('end', endFn);
+  if (state.endEmitted) pna.nextTick(endFn);else src.once('end', endFn);
 
   dest.on('unpipe', onunpipe);
   function onunpipe(readable, unpipeInfo) {
@@ -2999,7 +3121,7 @@ Readable.prototype.on = function (ev, fn) {
       state.readableListening = state.needReadable = true;
       state.emittedReadable = false;
       if (!state.reading) {
-        processNextTick(nReadingNextTick, this);
+        pna.nextTick(nReadingNextTick, this);
       } else if (state.length) {
         emitReadable(this);
       }
@@ -3030,7 +3152,7 @@ Readable.prototype.resume = function () {
 function resume(stream, state) {
   if (!state.resumeScheduled) {
     state.resumeScheduled = true;
-    processNextTick(resume_, stream, state);
+    pna.nextTick(resume_, stream, state);
   }
 }
 
@@ -3067,18 +3189,19 @@ function flow(stream) {
 // This is *not* part of the readable stream interface.
 // It is an ugly unfortunate mess of history.
 Readable.prototype.wrap = function (stream) {
+  var _this = this;
+
   var state = this._readableState;
   var paused = false;
 
-  var self = this;
   stream.on('end', function () {
     debug('wrapped end');
     if (state.decoder && !state.ended) {
       var chunk = state.decoder.end();
-      if (chunk && chunk.length) self.push(chunk);
+      if (chunk && chunk.length) _this.push(chunk);
     }
 
-    self.push(null);
+    _this.push(null);
   });
 
   stream.on('data', function (chunk) {
@@ -3088,7 +3211,7 @@ Readable.prototype.wrap = function (stream) {
     // don't skip over falsy values in objectMode
     if (state.objectMode && (chunk === null || chunk === undefined)) return;else if (!state.objectMode && (!chunk || !chunk.length)) return;
 
-    var ret = self.push(chunk);
+    var ret = _this.push(chunk);
     if (!ret) {
       paused = true;
       stream.pause();
@@ -3109,12 +3232,12 @@ Readable.prototype.wrap = function (stream) {
 
   // proxy certain important events.
   for (var n = 0; n < kProxyEvents.length; n++) {
-    stream.on(kProxyEvents[n], self.emit.bind(self, kProxyEvents[n]));
+    stream.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
   }
 
   // when we try to consume some more bytes, simply unpause the
   // underlying stream.
-  self._read = function (n) {
+  this._read = function (n) {
     debug('wrapped _read', n);
     if (paused) {
       paused = false;
@@ -3122,8 +3245,18 @@ Readable.prototype.wrap = function (stream) {
     }
   };
 
-  return self;
+  return this;
 };
+
+Object.defineProperty(Readable.prototype, 'readableHighWaterMark', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function () {
+    return this._readableState.highWaterMark;
+  }
+});
 
 // exposed for testing purposes only.
 Readable._fromList = fromList;
@@ -3237,7 +3370,7 @@ function endReadable(stream) {
 
   if (!state.endEmitted) {
     state.ended = true;
-    processNextTick(endReadableNT, state, stream);
+    pna.nextTick(endReadableNT, state, stream);
   }
 }
 
@@ -3247,12 +3380,6 @@ function endReadableNT(state, stream) {
     state.endEmitted = true;
     stream.readable = false;
     stream.emit('end');
-  }
-}
-
-function forEach(xs, f) {
-  for (var i = 0, l = xs.length; i < l; i++) {
-    f(xs[i], i);
   }
 }
 
@@ -3279,7 +3406,7 @@ module.exports = __webpack_require__(13);
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(10);
+var pna = __webpack_require__(10);
 /*</replacement>*/
 
 // undocumented cb() API, needed for core, not for public API
@@ -3293,9 +3420,9 @@ function destroy(err, cb) {
     if (cb) {
       cb(err);
     } else if (err && (!this._writableState || !this._writableState.errorEmitted)) {
-      processNextTick(emitErrorNT, this, err);
+      pna.nextTick(emitErrorNT, this, err);
     }
-    return;
+    return this;
   }
 
   // we set destroyed to true before firing error callbacks in order
@@ -3312,7 +3439,7 @@ function destroy(err, cb) {
 
   this._destroy(err || null, function (err) {
     if (!cb && err) {
-      processNextTick(emitErrorNT, _this, err);
+      pna.nextTick(emitErrorNT, _this, err);
       if (_this._writableState) {
         _this._writableState.errorEmitted = true;
       }
@@ -3320,6 +3447,8 @@ function destroy(err, cb) {
       cb(err);
     }
   });
+
+  return this;
 }
 
 function undestroy() {
@@ -3382,7 +3511,7 @@ module.exports = {
 
 /*<replacement>*/
 
-var processNextTick = __webpack_require__(10);
+var pna = __webpack_require__(10);
 /*</replacement>*/
 
 module.exports = Writable;
@@ -3409,7 +3538,7 @@ function CorkedRequest(state) {
 /* </replacement> */
 
 /*<replacement>*/
-var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : processNextTick;
+var asyncWrite = !process.browser && ['v0.10', 'v0.9.'].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : pna.nextTick;
 /*</replacement>*/
 
 /*<replacement>*/
@@ -3425,7 +3554,7 @@ util.inherits = __webpack_require__(7);
 
 /*<replacement>*/
 var internalUtil = {
-  deprecate: __webpack_require__(74)
+  deprecate: __webpack_require__(76)
 };
 /*</replacement>*/
 
@@ -3434,6 +3563,7 @@ var Stream = __webpack_require__(21);
 /*</replacement>*/
 
 /*<replacement>*/
+
 var Buffer = __webpack_require__(1).Buffer;
 var OurUint8Array = global.Uint8Array || function () {};
 function _uint8ArrayToBuffer(chunk) {
@@ -3442,6 +3572,7 @@ function _uint8ArrayToBuffer(chunk) {
 function _isUint8Array(obj) {
   return Buffer.isBuffer(obj) || obj instanceof OurUint8Array;
 }
+
 /*</replacement>*/
 
 var destroyImpl = __webpack_require__(22);
@@ -3455,18 +3586,27 @@ function WritableState(options, stream) {
 
   options = options || {};
 
+  // Duplex streams are both readable and writable, but share
+  // the same options object.
+  // However, some cases require setting options to different
+  // values for the readable and the writable sides of the duplex stream.
+  // These options can be provided separately as readableXXX and writableXXX.
+  var isDuplex = stream instanceof Duplex;
+
   // object stream flag to indicate whether or not this stream
   // contains buffers or objects.
   this.objectMode = !!options.objectMode;
 
-  if (stream instanceof Duplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
+  if (isDuplex) this.objectMode = this.objectMode || !!options.writableObjectMode;
 
   // the point at which write() starts returning false
   // Note: 0 is a valid value, means that we always return false if
   // the entire buffer is not flushed immediately on write()
   var hwm = options.highWaterMark;
+  var writableHwm = options.writableHighWaterMark;
   var defaultHwm = this.objectMode ? 16 : 16 * 1024;
-  this.highWaterMark = hwm || hwm === 0 ? hwm : defaultHwm;
+
+  if (hwm || hwm === 0) this.highWaterMark = hwm;else if (isDuplex && (writableHwm || writableHwm === 0)) this.highWaterMark = writableHwm;else this.highWaterMark = defaultHwm;
 
   // cast to ints.
   this.highWaterMark = Math.floor(this.highWaterMark);
@@ -3580,6 +3720,7 @@ if (typeof Symbol === 'function' && Symbol.hasInstance && typeof Function.protot
   Object.defineProperty(Writable, Symbol.hasInstance, {
     value: function (object) {
       if (realHasInstance.call(this, object)) return true;
+      if (this !== Writable) return false;
 
       return object && object._writableState instanceof WritableState;
     }
@@ -3631,7 +3772,7 @@ function writeAfterEnd(stream, cb) {
   var er = new Error('write after end');
   // TODO: defer error events consistently everywhere, not just the cb
   stream.emit('error', er);
-  processNextTick(cb, er);
+  pna.nextTick(cb, er);
 }
 
 // Checks that a user-supplied chunk is valid, especially for the particular
@@ -3648,7 +3789,7 @@ function validChunk(stream, state, chunk, cb) {
   }
   if (er) {
     stream.emit('error', er);
-    processNextTick(cb, er);
+    pna.nextTick(cb, er);
     valid = false;
   }
   return valid;
@@ -3657,7 +3798,7 @@ function validChunk(stream, state, chunk, cb) {
 Writable.prototype.write = function (chunk, encoding, cb) {
   var state = this._writableState;
   var ret = false;
-  var isBuf = _isUint8Array(chunk) && !state.objectMode;
+  var isBuf = !state.objectMode && _isUint8Array(chunk);
 
   if (isBuf && !Buffer.isBuffer(chunk)) {
     chunk = _uint8ArrayToBuffer(chunk);
@@ -3710,6 +3851,16 @@ function decodeChunk(state, chunk, encoding) {
   }
   return chunk;
 }
+
+Object.defineProperty(Writable.prototype, 'writableHighWaterMark', {
+  // making it explicit this property is not enumerable
+  // because otherwise some prototype manipulation in
+  // userland will fail
+  enumerable: false,
+  get: function () {
+    return this._writableState.highWaterMark;
+  }
+});
 
 // if we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
@@ -3768,10 +3919,10 @@ function onwriteError(stream, state, sync, er, cb) {
   if (sync) {
     // defer the callback if we are being called synchronously
     // to avoid piling up things on the stack
-    processNextTick(cb, er);
+    pna.nextTick(cb, er);
     // this can emit finish, and it will always happen
     // after error
-    processNextTick(finishMaybe, stream, state);
+    pna.nextTick(finishMaybe, stream, state);
     stream._writableState.errorEmitted = true;
     stream.emit('error', er);
   } else {
@@ -3869,6 +4020,7 @@ function clearBuffer(stream, state) {
     } else {
       state.corkedRequestsFree = new CorkedRequest(state);
     }
+    state.bufferedRequestCount = 0;
   } else {
     // Slow case, write chunks one-by-one
     while (entry) {
@@ -3879,6 +4031,7 @@ function clearBuffer(stream, state) {
 
       doWrite(stream, state, false, len, chunk, encoding, cb);
       entry = entry.next;
+      state.bufferedRequestCount--;
       // if we didn't call the onwrite immediately, then
       // it means that we need to wait until it does.
       // also, that means that the chunk and cb are currently
@@ -3891,7 +4044,6 @@ function clearBuffer(stream, state) {
     if (entry === null) state.lastBufferedRequest = null;
   }
 
-  state.bufferedRequestCount = 0;
   state.bufferedRequest = entry;
   state.bufferProcessing = false;
 }
@@ -3945,7 +4097,7 @@ function prefinish(stream, state) {
     if (typeof stream._final === 'function') {
       state.pendingcb++;
       state.finalCalled = true;
-      processNextTick(callFinal, stream, state);
+      pna.nextTick(callFinal, stream, state);
     } else {
       state.prefinished = true;
       stream.emit('prefinish');
@@ -3969,7 +4121,7 @@ function endWritable(stream, state, cb) {
   state.ending = true;
   finishMaybe(stream, state);
   if (cb) {
-    if (state.finished) processNextTick(cb);else stream.once('finish', cb);
+    if (state.finished) pna.nextTick(cb);else stream.once('finish', cb);
   }
   state.ended = true;
   stream.writable = false;
@@ -4023,9 +4175,33 @@ Writable.prototype._destroy = function (err, cb) {
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
+
+/*<replacement>*/
 
 var Buffer = __webpack_require__(1).Buffer;
+/*</replacement>*/
 
 var isEncoding = Buffer.isEncoding || function (encoding) {
   encoding = '' + encoding;
@@ -4137,10 +4313,10 @@ StringDecoder.prototype.fillLast = function (buf) {
 };
 
 // Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
-// continuation byte.
+// continuation byte. If an invalid byte is detected, -2 is returned.
 function utf8CheckByte(byte) {
   if (byte <= 0x7F) return 0;else if (byte >> 5 === 0x06) return 2;else if (byte >> 4 === 0x0E) return 3;else if (byte >> 3 === 0x1E) return 4;
-  return -1;
+  return byte >> 6 === 0x02 ? -1 : -2;
 }
 
 // Checks at most 3 bytes at the end of a Buffer in order to detect an
@@ -4154,13 +4330,13 @@ function utf8CheckIncomplete(self, buf, i) {
     if (nb > 0) self.lastNeed = nb - 1;
     return nb;
   }
-  if (--j < i) return 0;
+  if (--j < i || nb === -2) return 0;
   nb = utf8CheckByte(buf[j]);
   if (nb >= 0) {
     if (nb > 0) self.lastNeed = nb - 2;
     return nb;
   }
-  if (--j < i) return 0;
+  if (--j < i || nb === -2) return 0;
   nb = utf8CheckByte(buf[j]);
   if (nb >= 0) {
     if (nb > 0) {
@@ -4174,7 +4350,7 @@ function utf8CheckIncomplete(self, buf, i) {
 // Validates as many continuation bytes for a multi-byte UTF-8 character as
 // needed or are available. If we see a non-continuation byte where we expect
 // one, we "replace" the validated continuation bytes we've seen so far with
-// UTF-8 replacement characters ('\ufffd'), to match v8's UTF-8 decoding
+// a single UTF-8 replacement character ('\ufffd'), to match v8's UTF-8 decoding
 // behavior. The continuation byte check is included three times in the case
 // where all of the continuation bytes for a character exist in the same buffer.
 // It is also done this way as a slight performance increase instead of using a
@@ -4182,17 +4358,17 @@ function utf8CheckIncomplete(self, buf, i) {
 function utf8CheckExtraBytes(self, buf, p) {
   if ((buf[0] & 0xC0) !== 0x80) {
     self.lastNeed = 0;
-    return '\ufffd'.repeat(p);
+    return '\ufffd';
   }
   if (self.lastNeed > 1 && buf.length > 1) {
     if ((buf[1] & 0xC0) !== 0x80) {
       self.lastNeed = 1;
-      return '\ufffd'.repeat(p + 1);
+      return '\ufffd';
     }
     if (self.lastNeed > 2 && buf.length > 2) {
       if ((buf[2] & 0xC0) !== 0x80) {
         self.lastNeed = 2;
-        return '\ufffd'.repeat(p + 2);
+        return '\ufffd';
       }
     }
   }
@@ -4223,11 +4399,11 @@ function utf8Text(buf, i) {
   return buf.toString('utf8', i, end);
 }
 
-// For UTF-8, a replacement character for each buffered byte of a (partial)
-// character needs to be added to the output.
+// For UTF-8, a replacement character is added when ending on a partial
+// character.
 function utf8End(buf) {
   var r = buf && buf.length ? this.write(buf) : '';
-  if (this.lastNeed) return r + '\ufffd'.repeat(this.lastTotal - this.lastNeed);
+  if (this.lastNeed) return r + '\ufffd';
   return r;
 }
 
@@ -4377,39 +4553,28 @@ util.inherits = __webpack_require__(7);
 
 util.inherits(Transform, Duplex);
 
-function TransformState(stream) {
-  this.afterTransform = function (er, data) {
-    return afterTransform(stream, er, data);
-  };
-
-  this.needTransform = false;
-  this.transforming = false;
-  this.writecb = null;
-  this.writechunk = null;
-  this.writeencoding = null;
-}
-
-function afterTransform(stream, er, data) {
-  var ts = stream._transformState;
+function afterTransform(er, data) {
+  var ts = this._transformState;
   ts.transforming = false;
 
   var cb = ts.writecb;
 
   if (!cb) {
-    return stream.emit('error', new Error('write callback called multiple times'));
+    return this.emit('error', new Error('write callback called multiple times'));
   }
 
   ts.writechunk = null;
   ts.writecb = null;
 
-  if (data !== null && data !== undefined) stream.push(data);
+  if (data != null) // single equals check for both `null` and `undefined`
+    this.push(data);
 
   cb(er);
 
-  var rs = stream._readableState;
+  var rs = this._readableState;
   rs.reading = false;
   if (rs.needReadable || rs.length < rs.highWaterMark) {
-    stream._read(rs.highWaterMark);
+    this._read(rs.highWaterMark);
   }
 }
 
@@ -4418,9 +4583,14 @@ function Transform(options) {
 
   Duplex.call(this, options);
 
-  this._transformState = new TransformState(this);
-
-  var stream = this;
+  this._transformState = {
+    afterTransform: afterTransform.bind(this),
+    needTransform: false,
+    transforming: false,
+    writecb: null,
+    writechunk: null,
+    writeencoding: null
+  };
 
   // start out asking for a readable event once data is transformed.
   this._readableState.needReadable = true;
@@ -4437,11 +4607,19 @@ function Transform(options) {
   }
 
   // When the writable side finishes, then flush out anything remaining.
-  this.once('prefinish', function () {
-    if (typeof this._flush === 'function') this._flush(function (er, data) {
-      done(stream, er, data);
-    });else done(stream);
-  });
+  this.on('prefinish', prefinish);
+}
+
+function prefinish() {
+  var _this = this;
+
+  if (typeof this._flush === 'function') {
+    this._flush(function (er, data) {
+      done(_this, er, data);
+    });
+  } else {
+    done(this, null, null);
+  }
 }
 
 Transform.prototype.push = function (chunk, encoding) {
@@ -4491,27 +4669,25 @@ Transform.prototype._read = function (n) {
 };
 
 Transform.prototype._destroy = function (err, cb) {
-  var _this = this;
+  var _this2 = this;
 
   Duplex.prototype._destroy.call(this, err, function (err2) {
     cb(err2);
-    _this.emit('close');
+    _this2.emit('close');
   });
 };
 
 function done(stream, er, data) {
   if (er) return stream.emit('error', er);
 
-  if (data !== null && data !== undefined) stream.push(data);
+  if (data != null) // single equals check for both `null` and `undefined`
+    stream.push(data);
 
   // if there's nothing in the write buffer, then that means
   // that nothing more will ever be provided
-  var ws = stream._writableState;
-  var ts = stream._transformState;
+  if (stream._writableState.length) throw new Error('Calling transform done when ws.length != 0');
 
-  if (ws.length) throw new Error('Calling transform done when ws.length != 0');
-
-  if (ts.transforming) throw new Error('Calling transform done when still transforming');
+  if (stream._transformState.transforming) throw new Error('Calling transform done when still transforming');
 
   return stream.push(null);
 }
@@ -4520,7 +4696,7 @@ function done(stream, er, data) {
 /* 26 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(80);
+module.exports = __webpack_require__(81);
 
 
 /***/ }),
@@ -4531,7 +4707,7 @@ var mysql          = __webpack_require__(14);
 var Connection     = __webpack_require__(8);
 var EventEmitter   = __webpack_require__(4).EventEmitter;
 var Util           = __webpack_require__(0);
-var PoolConnection = __webpack_require__(82);
+var PoolConnection = __webpack_require__(83);
 
 module.exports = Pool;
 
@@ -4999,7 +5175,7 @@ global.exports('mysql_fetch_scalar', (query, parameters, callback) => {
     const invokingResource = global.GetInvokingResource();
     let sql = prepareQuery(query, parameters);
     execute({ sql, typeCast }, invokingResource).then((result) => {
-        safeInvoke(callback, (result) ? Object.values(result[0])[0] : null);
+        safeInvoke(callback, (result && Array.isArray(result) && result.length > 0) ? Object.values(result[0])[0] : null);
     });
 });
 
@@ -5580,6 +5756,43 @@ exports['Amazon RDS'] = {
     + '-----END CERTIFICATE-----\n',
 
     /**
+     * Amazon RDS us-east-2 certificate CA 2016 to 2020
+     *
+     *   CN = Amazon RDS us-east-2 CA
+     *   OU = Amazon RDS
+     *   O = Amazon Web Services, Inc.
+     *   L = Seattle
+     *   ST = Washington
+     *   C = US
+     *   P = 2016-08-11T19:58:45Z/2020-03-05T19:58:45Z
+     *   F = 9B:78:E3:64:7F:74:BC:B2:52:18:CF:13:C3:62:B8:35:9D:3D:5F:B6
+     */
+    '-----BEGIN CERTIFICATE-----\n'
+    + 'MIID/DCCAuSgAwIBAgIBTjANBgkqhkiG9w0BAQsFADCBijELMAkGA1UEBhMCVVMx\n'
+    + 'EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM\n'
+    + 'GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx\n'
+    + 'GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNjA4MTExOTU4NDVaFw0y\n'
+    + 'MDAzMDUxOTU4NDVaMIGPMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv\n'
+    + 'bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl\n'
+    + 'cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEgMB4GA1UEAwwXQW1hem9uIFJE\n'
+    + 'UyB1cy1lYXN0LTIgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCp\n'
+    + 'WnnUX7wM0zzstccX+4iXKJa9GR0a2PpvB1paEX4QRCgfhEdQWDaSqyrWNgdVCKkt\n'
+    + '1aQkWu5j6VAC2XIG7kKoonm1ZdBVyBLqW5lXNywlaiU9yhJkwo8BR+/OqgE+PLt/\n'
+    + 'EO1mlN0PQudja/XkExCXTO29TG2j7F/O7hox6vTyHNHc0H88zS21uPuBE+jivViS\n'
+    + 'yzj/BkyoQ85hnkues3f9R6gCGdc+J51JbZnmgzUkvXjAEuKhAm9JksVOxcOKUYe5\n'
+    + 'ERhn0U9zjzpfbAITIkul97VVa5IxskFFTHIPJbvRKHJkiF6wTJww/tc9wm+fSCJ1\n'
+    + '+DbQTGZgkQ3bJrqRN29/AgMBAAGjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMB\n'
+    + 'Af8ECDAGAQH/AgEAMB0GA1UdDgQWBBSAHQzUYYZbepwKEMvGdHp8wzHnfDAfBgNV\n'
+    + 'HSMEGDAWgBROAu6sPvYVyEztLPUFwY+chAhJgzANBgkqhkiG9w0BAQsFAAOCAQEA\n'
+    + 'MbaEzSYZ+aZeTBxf8yi0ta8K4RdwEJsEmP6IhFFQHYUtva2Cynl4Q9tZg3RMsybT\n'
+    + '9mlnSQQlbN/wqIIXbkrcgFcHoXG9Odm/bDtUwwwDaiEhXVfeQom3G77QHOWMTCGK\n'
+    + 'qadwuh5msrb17JdXZoXr4PYHDKP7j0ONfAyFNER2+uecblHfRSpVq5UeF3L6ZJb8\n'
+    + 'fSw/GtAV6an+/0r+Qm+PiI2H5XuZ4GmRJYnGMhqWhBYrY7p3jtVnKcsh39wgfUnW\n'
+    + 'AvZEZG/yhFyAZW0Essa39LiL5VSq14Y1DOj0wgnhSY/9WHxaAo1HB1T9OeZknYbD\n'
+    + 'fl/EGSZ0TEvZkENrXcPlVA==\n'
+    + '-----END CERTIFICATE-----\n',
+
+    /**
      * Amazon RDS ca-central-1 certificate CA 2016 to 2020
      *
      *   CN = Amazon RDS ca-central-1 CA
@@ -5651,6 +5864,154 @@ exports['Amazon RDS'] = {
     + 'JesWxBMXXGoDC1rIYTFO7szwDyOHlCcVXJDNsTJhc32oDWYdeIbW7o/5I+aQsrXZ\n'
     + 'C96HykZcgWzz6sElrQxUaT3IoMw/5nmw4uWKKnZnxgI9bY4fpQwMeBZ96iHfFxvH\n'
     + 'mqfEEuC7uUoPofXdBp2ObQ==\n'
+    + '-----END CERTIFICATE-----\n',
+
+    /**
+     * Amazon RDS us-gov-west-1 CA 2017 to 2022
+     *
+     *   CN = Amazon RDS us-gov-west-1 CA
+     *   OU = Amazon RDS
+     *   O = Amazon Web Services, Inc.
+     *   L = Seattle
+     *   ST = Washington
+     *   C = US
+     *   P = 2017-05-19T22:31:19Z/2022-05-18T12:00:00Z
+     *   F = 77:55:8C:C4:5E:71:1F:1B:57:E3:DA:6E:5B:74:27:12:4E:E8:69:E8
+     */
+    '-----BEGIN CERTIFICATE-----\n'
+    + 'MIIECjCCAvKgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwgZMxCzAJBgNVBAYTAlVT\n'
+    + 'MRAwDgYDVQQHDAdTZWF0dGxlMRMwEQYDVQQIDApXYXNoaW5ndG9uMSIwIAYDVQQK\n'
+    + 'DBlBbWF6b24gV2ViIFNlcnZpY2VzLCBJbmMuMRMwEQYDVQQLDApBbWF6b24gUkRT\n'
+    + 'MSQwIgYDVQQDDBtBbWF6b24gUkRTIEdvdkNsb3VkIFJvb3QgQ0EwHhcNMTcwNTE5\n'
+    + 'MjIzMTE5WhcNMjIwNTE4MTIwMDAwWjCBkzELMAkGA1UEBhMCVVMxEzARBgNVBAgM\n'
+    + 'Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoMGUFtYXpvbiBX\n'
+    + 'ZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMxJDAiBgNVBAMM\n'
+    + 'G0FtYXpvbiBSRFMgdXMtZ292LXdlc3QtMSBDQTCCASIwDQYJKoZIhvcNAQEBBQAD\n'
+    + 'ggEPADCCAQoCggEBAM8YZLKAzzOdNnoi7Klih26Zkj+OCpDfwx4ZYB6f8L8UoQi5\n'
+    + '8z9ZtIwMjiJ/kO08P1yl4gfc7YZcNFvhGruQZNat3YNpxwUpQcr4mszjuffbL4uz\n'
+    + '+/8FBxALdqCVOJ5Q0EVSfz3d9Bd1pUPL7ARtSpy7bn/tUPyQeI+lODYO906C0TQ3\n'
+    + 'b9bjOsgAdBKkHfjLdsknsOZYYIzYWOJyFJJa0B11XjDUNBy/3IuC0KvDl6At0V5b\n'
+    + '8M6cWcKhte2hgjwTYepV+/GTadeube1z5z6mWsN5arOAQUtYDLH6Aztq9mCJzLHm\n'
+    + 'RccBugnGl3fRLJ2VjioN8PoGoN9l9hFBy5fnFgsCAwEAAaNmMGQwDgYDVR0PAQH/\n'
+    + 'BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFEG7+br8KkvwPd5g\n'
+    + '71Rvh2stclJbMB8GA1UdIwQYMBaAFEkQz6S4NS5lOYKcDjBSuCcVpdzjMA0GCSqG\n'
+    + 'SIb3DQEBCwUAA4IBAQBMA327u5ABmhX+aPxljoIbxnydmAFWxW6wNp5+rZrvPig8\n'
+    + 'zDRqGQWWr7wWOIjfcWugSElYtf/m9KZHG/Z6+NG7nAoUrdcd1h/IQhb+lFQ2b5g9\n'
+    + 'sVzQv/H2JNkfZA8fL/Ko/Tm/f9tcqe0zrGCtT+5u0Nvz35Wl8CEUKLloS5xEb3k5\n'
+    + '7D9IhG3fsE3vHWlWrGCk1cKry3j12wdPG5cUsug0vt34u6rdhP+FsM0tHI15Kjch\n'
+    + 'RuUCvyQecy2ZFNAa3jmd5ycNdL63RWe8oayRBpQBxPPCbHfILxGZEdJbCH9aJ2D/\n'
+    + 'l8oHIDnvOLdv7/cBjyYuvmprgPtu3QEkbre5Hln/\n'
+    + '-----END CERTIFICATE-----\n',
+
+    /**
+     * Amazon RDS eu-west-3 certificate CA 2017 to 2020
+     *
+     *   CN = Amazon RDS eu-west-3 CA
+     *   OU = Amazon RDS
+     *   O = Amazon Web Services, Inc.
+     *   L = Seattle
+     *   ST = Washington
+     *   C = US
+     *   P = 2017-08-25T21:39:26Z/2020-03-05T21:39:26Z
+     *   F = FD:35:A7:84:60:68:98:00:12:54:ED:34:26:8C:66:0F:72:DD:B2:F4
+     */
+    '-----BEGIN CERTIFICATE-----\n'
+    + 'MIID/DCCAuSgAwIBAgIBUTANBgkqhkiG9w0BAQsFADCBijELMAkGA1UEBhMCVVMx\n'
+    + 'EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM\n'
+    + 'GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx\n'
+    + 'GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNzA4MjUyMTM5MjZaFw0y\n'
+    + 'MDAzMDUyMTM5MjZaMIGPMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv\n'
+    + 'bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl\n'
+    + 'cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzEgMB4GA1UEAwwXQW1hem9uIFJE\n'
+    + 'UyBldS13ZXN0LTMgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+\n'
+    + 'xmlEC/3a4cJH+UPwXCE02lC7Zq5NHd0dn6peMeLN8agb6jW4VfSY0NydjRj2DJZ8\n'
+    + 'K7wV6sub5NUGT1NuFmvSmdbNR2T59KX0p2dVvxmXHHtIpQ9Y8Aq3ZfhmC5q5Bqgw\n'
+    + 'tMA1xayDi7HmoPX3R8kk9ktAZQf6lDeksCvok8idjTu9tiSpDiMwds5BjMsWfyjZ\n'
+    + 'd13PTGGNHYVdP692BSyXzSP1Vj84nJKnciW8tAqwIiadreJt5oXyrCXi8ekUMs80\n'
+    + 'cUTuGm3aA3Q7PB5ljJMPqz0eVddaiIvmTJ9O3Ez3Du/HpImyMzXjkFaf+oNXf/Hx\n'
+    + '/EW5jCRR6vEiXJcDRDS7AgMBAAGjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMB\n'
+    + 'Af8ECDAGAQH/AgEAMB0GA1UdDgQWBBRZ9mRtS5fHk3ZKhG20Oack4cAqMTAfBgNV\n'
+    + 'HSMEGDAWgBROAu6sPvYVyEztLPUFwY+chAhJgzANBgkqhkiG9w0BAQsFAAOCAQEA\n'
+    + 'F/u/9L6ExQwD73F/bhCw7PWcwwqsK1mypIdrjdIsu0JSgwWwGCXmrIspA3n3Dqxq\n'
+    + 'sMhAJD88s9Em7337t+naar2VyLO63MGwjj+vA4mtvQRKq8ScIpiEc7xN6g8HUMsd\n'
+    + 'gPG9lBGfNjuAZsrGJflrko4HyuSM7zHExMjXLH+CXcv/m3lWOZwnIvlVMa4x0Tz0\n'
+    + 'A4fklaawryngzeEjuW6zOiYCzjZtPlP8Fw0SpzppJ8VpQfrZ751RDo4yudmPqoPK\n'
+    + '5EUe36L8U+oYBXnC5TlYs9bpVv9o5wJQI5qA9oQE2eFWxF1E0AyZ4V5sgGUBStaX\n'
+    + 'BjDDWul0wSo7rt1Tq7XpnA==\n'
+    + '-----END CERTIFICATE-----\n',
+
+    /**
+     * Amazon RDS ap-northeast-3 certificate CA 2017 to 2020
+     *
+     *   CN = Amazon RDS ap-northeast-3 CA
+     *   OU = Amazon RDS
+     *   O = Amazon Web Services, Inc.
+     *   L = Seattle
+     *   ST = Washington
+     *   C = US
+     *   P = 2017-12-01T00:55:42Z/2020-03-05T00:55:42Z
+     *   F = C0:C7:D4:B3:91:40:A0:77:43:28:BF:AF:77:57:DF:FD:98:FB:10:3F
+     */
+    '-----BEGIN CERTIFICATE-----\n'
+    + 'MIIEATCCAumgAwIBAgIBTjANBgkqhkiG9w0BAQUFADCBijELMAkGA1UEBhMCVVMx\n'
+    + 'EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxIjAgBgNVBAoM\n'
+    + 'GUFtYXpvbiBXZWIgU2VydmljZXMsIEluYy4xEzARBgNVBAsMCkFtYXpvbiBSRFMx\n'
+    + 'GzAZBgNVBAMMEkFtYXpvbiBSRFMgUm9vdCBDQTAeFw0xNzEyMDEwMDU1NDJaFw0y\n'
+    + 'MDAzMDUwMDU1NDJaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3Rv\n'
+    + 'bjEQMA4GA1UEBwwHU2VhdHRsZTEiMCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNl\n'
+    + 'cywgSW5jLjETMBEGA1UECwwKQW1hem9uIFJEUzElMCMGA1UEAwwcQW1hem9uIFJE\n'
+    + 'UyBhcC1ub3J0aGVhc3QtMyBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\n'
+    + 'ggEBAMZtQNnm/XT19mTa10ftHLzg5UhajoI65JHv4TQNdGXdsv+CQdGYU49BJ9Eu\n'
+    + '3bYgiEtTzR2lQe9zGMvtuJobLhOWuavzp7IixoIQcHkFHN6wJ1CvqrxgvJfBq6Hy\n'
+    + 'EuCDCiU+PPDLUNA6XM6Qx3IpHd1wrJkjRB80dhmMSpxmRmx849uFafhN+P1QybsM\n'
+    + 'TI0o48VON2+vj+mNuQTyLMMP8D4odSQHjaoG+zyJfJGZeAyqQyoOUOFEyQaHC3TT\n'
+    + '3IDSNCQlpxb9LerbCoKu79WFBBq3CS5cYpg8/fsnV2CniRBFFUumBt5z4dhw9RJU\n'
+    + 'qlUXXO1ZyzpGd+c5v6FtrfXtnIUCAwEAAaNmMGQwDgYDVR0PAQH/BAQDAgEGMBIG\n'
+    + 'A1UdEwEB/wQIMAYBAf8CAQAwHQYDVR0OBBYEFETv7ELNplYy/xTeIOInl6nzeiHg\n'
+    + 'MB8GA1UdIwQYMBaAFE4C7qw+9hXITO0s9QXBj5yECEmDMA0GCSqGSIb3DQEBBQUA\n'
+    + 'A4IBAQCpKxOQcd0tEKb3OtsOY8q/MPwTyustGk2Rt7t9G68idADp8IytB7M0SDRo\n'
+    + 'wWZqynEq7orQVKdVOanhEWksNDzGp0+FPAf/KpVvdYCd7ru3+iI+V4ZEp2JFdjuZ\n'
+    + 'Zz0PIjS6AgsZqE5Ri1J+NmfmjGZCPhsHnGZiBaenX6K5VRwwwmLN6xtoqrrfR5zL\n'
+    + 'QfBeeZNJG6KiM3R/DxJ5rAa6Fz+acrhJ60L7HprhB7SFtj1RCijau3+ZwiGmUOMr\n'
+    + 'yKlMv+VgmzSw7o4Hbxy1WVrA6zQsTHHSGf+vkQn2PHvnFMUEu/ZLbTDYFNmTLK91\n'
+    + 'K6o4nMsEvhBKgo4z7H1EqqxXhvN2\n'
+    + '-----END CERTIFICATE-----\n',
+
+    /**
+     * Amazon RDS GovCloud Root CA 2017 to 2022
+     *
+     *   CN = Amazon RDS GovCloud Root CA
+     *   OU = Amazon RDS
+     *   O = Amazon Web Services, Inc.
+     *   L = Seattle
+     *   ST = Washington
+     *   C = US
+     *   P = 2017-05-19T22:29:11Z/2022-05-18T22:29:11Z
+     *   F = A3:61:F9:C9:A2:5B:91:FE:73:A6:52:E3:59:14:8E:CE:35:12:0F:FD
+     */
+    '-----BEGIN CERTIFICATE-----\n'
+    + 'MIIEDjCCAvagAwIBAgIJAMM61RQn3/kdMA0GCSqGSIb3DQEBCwUAMIGTMQswCQYD\n'
+    + 'VQQGEwJVUzEQMA4GA1UEBwwHU2VhdHRsZTETMBEGA1UECAwKV2FzaGluZ3RvbjEi\n'
+    + 'MCAGA1UECgwZQW1hem9uIFdlYiBTZXJ2aWNlcywgSW5jLjETMBEGA1UECwwKQW1h\n'
+    + 'em9uIFJEUzEkMCIGA1UEAwwbQW1hem9uIFJEUyBHb3ZDbG91ZCBSb290IENBMB4X\n'
+    + 'DTE3MDUxOTIyMjkxMVoXDTIyMDUxODIyMjkxMVowgZMxCzAJBgNVBAYTAlVTMRAw\n'
+    + 'DgYDVQQHDAdTZWF0dGxlMRMwEQYDVQQIDApXYXNoaW5ndG9uMSIwIAYDVQQKDBlB\n'
+    + 'bWF6b24gV2ViIFNlcnZpY2VzLCBJbmMuMRMwEQYDVQQLDApBbWF6b24gUkRTMSQw\n'
+    + 'IgYDVQQDDBtBbWF6b24gUkRTIEdvdkNsb3VkIFJvb3QgQ0EwggEiMA0GCSqGSIb3\n'
+    + 'DQEBAQUAA4IBDwAwggEKAoIBAQDGS9bh1FGiJPT+GRb3C5aKypJVDC1H2gbh6n3u\n'
+    + 'j8cUiyMXfmm+ak402zdLpSYMaxiQ7oL/B3wEmumIpRDAsQrSp3B/qEeY7ipQGOfh\n'
+    + 'q2TXjXGIUjiJ/FaoGqkymHRLG+XkNNBtb7MRItsjlMVNELXECwSiMa3nJL2/YyHW\n'
+    + 'nTr1+11/weeZEKgVbCUrOugFkMXnfZIBSn40j6EnRlO2u/NFU5ksK5ak2+j8raZ7\n'
+    + 'xW7VXp9S1Tgf1IsWHjGZZZguwCkkh1tHOlHC9gVA3p63WecjrIzcrR/V27atul4m\n'
+    + 'tn56s5NwFvYPUIx1dbC8IajLUrepVm6XOwdQCfd02DmOyjWJAgMBAAGjYzBhMA4G\n'
+    + 'A1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRJEM+kuDUu\n'
+    + 'ZTmCnA4wUrgnFaXc4zAfBgNVHSMEGDAWgBRJEM+kuDUuZTmCnA4wUrgnFaXc4zAN\n'
+    + 'BgkqhkiG9w0BAQsFAAOCAQEAcfA7uirXsNZyI2j4AJFVtOTKOZlQwqbyNducnmlg\n'
+    + '/5nug9fAkwM4AgvF5bBOD1Hw6khdsccMwIj+1S7wpL+EYb/nSc8G0qe1p/9lZ/mZ\n'
+    + 'ff5g4JOa26lLuCrZDqAk4TzYnt6sQKfa5ZXVUUn0BK3okhiXS0i+NloMyaBCL7vk\n'
+    + 'kDwkHwEqflRKfZ9/oFTcCfoiHPA7AdBtaPVr0/Kj9L7k+ouz122huqG5KqX0Zpo8\n'
+    + 'S0IGvcd2FZjNSNPttNAK7YuBVsZ0m2nIH1SLp//00v7yAHIgytQwwB17PBcp4NXD\n'
+    + 'pCfTa27ng9mMMC2YLqWQpW4TkqjDin2ZC+5X/mbrjzTvVg==\n'
     + '-----END CERTIFICATE-----\n'
   ]
 };
@@ -5663,10 +6024,9 @@ exports['Amazon RDS'] = {
 var Parser       = __webpack_require__(36);
 var Sequences    = __webpack_require__(41);
 var Packets      = __webpack_require__(2);
-var Timers       = __webpack_require__(78);
 var Stream       = __webpack_require__(13).Stream;
 var Util         = __webpack_require__(0);
-var PacketWriter = __webpack_require__(79);
+var PacketWriter = __webpack_require__(80);
 
 module.exports = Protocol;
 Util.inherits(Protocol, Stream);
@@ -5816,11 +6176,8 @@ Protocol.prototype._enqueue = function(sequence) {
       self._delegateError(err, sequence);
     })
     .on('packet', function(packet) {
-      Timers.active(sequence);
+      sequence._timer.active();
       self._emitPacket(packet);
-    })
-    .on('end', function() {
-      self._dequeue(sequence);
     })
     .on('timeout', function() {
       var err = new Error(sequence.constructor.name + ' inactivity timeout');
@@ -5830,9 +6187,11 @@ Protocol.prototype._enqueue = function(sequence) {
       err.timeout = sequence._timeout;
 
       self._delegateError(err, sequence);
-    })
-    .on('start-tls', function() {
-      Timers.active(sequence);
+    });
+
+  if (sequence.constructor === Sequences.Handshake) {
+    sequence.on('start-tls', function () {
+      sequence._timer.active();
       self._connection._startTLS(function(err) {
         if (err) {
           // SSL negotiation error are fatal
@@ -5842,10 +6201,23 @@ Protocol.prototype._enqueue = function(sequence) {
           return;
         }
 
-        Timers.active(sequence);
+        sequence._timer.active();
         sequence._tlsUpgradeCompleteHandler();
       });
     });
+
+    sequence.on('end', function () {
+      self._handshaked = true;
+
+      if (!self._fatalError) {
+        self.emit('handshake', self._handshakeInitializationPacket);
+      }
+    });
+  }
+
+  sequence.on('end', function () {
+    self._dequeue(sequence);
+  });
 
   if (this._queue.length === 1) {
     this._parser.resetPacketNumber();
@@ -5925,9 +6297,10 @@ Protocol.prototype._parsePacket = function() {
 
   if (Packet === Packets.HandshakeInitializationPacket) {
     this._handshakeInitializationPacket = packet;
+    this.emit('initialize', packet);
   }
 
-  Timers.active(sequence);
+  sequence._timer.active();
 
   if (!sequence[packetName]) {
     var err   = new Error('Received packet in the wrong sequence.');
@@ -5970,12 +6343,7 @@ Protocol.prototype._determinePacket = function(sequence) {
   }
 
   switch (firstByte) {
-    case 0x00:
-      if (!this._handshaked) {
-        this._handshaked = true;
-        this.emit('handshake', this._handshakeInitializationPacket);
-      }
-      return Packets.OkPacket;
+    case 0x00: return Packets.OkPacket;
     case 0xfe: return Packets.EofPacket;
     case 0xff: return Packets.ErrorPacket;
   }
@@ -5984,7 +6352,7 @@ Protocol.prototype._determinePacket = function(sequence) {
 };
 
 Protocol.prototype._dequeue = function(sequence) {
-  Timers.unenroll(sequence);
+  sequence._timer.stop();
 
   // No point in advancing the queue, we are dead
   if (this._fatalError) {
@@ -6006,8 +6374,7 @@ Protocol.prototype._dequeue = function(sequence) {
 
 Protocol.prototype._startSequence = function(sequence) {
   if (sequence._timeout > 0 && isFinite(sequence._timeout)) {
-    Timers.enroll(sequence, sequence._timeout);
-    Timers.active(sequence);
+    sequence._timer.start(sequence._timeout);
   }
 
   if (sequence.constructor === Sequences.ChangeUser) {
@@ -6099,20 +6466,23 @@ Protocol.prototype.destroy = function() {
 };
 
 Protocol.prototype._debugPacket = function(incoming, packet) {
-  var headline = (incoming)
-    ? '<-- '
-    : '--> ';
-
-  headline = headline + packet.constructor.name;
+  var connection = this._connection;
+  var direction  = incoming
+    ? '<--'
+    : '-->';
+  var packetName = packet.constructor.name;
+  var threadId   = connection && connection.threadId !== null
+    ? ' (' + connection.threadId + ')'
+    : '';
 
   // check for debug packet restriction
-  if (Array.isArray(this._config.debug) && this._config.debug.indexOf(packet.constructor.name) === -1) {
+  if (Array.isArray(this._config.debug) && this._config.debug.indexOf(packetName) === -1) {
     return;
   }
 
-  console.log(headline);
-  console.log(packet);
-  console.log('');
+  var packetPayload = Util.inspect(packet).replace(/^[^{]+/, '');
+
+  console.log('%s%s %s %s\n', direction, threadId, packetName, packetPayload);
 };
 
 
@@ -6120,12 +6490,14 @@ Protocol.prototype._debugPacket = function(incoming, packet) {
 /* 36 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var MAX_PACKET_LENGTH = Math.pow(2, 24) - 1;
-var MUL_32BIT         = Math.pow(2, 32);
-var PacketHeader      = __webpack_require__(37);
-var BigNumber         = __webpack_require__(38);
-var Buffer            = __webpack_require__(1).Buffer;
-var BufferList        = __webpack_require__(40);
+var PacketHeader = __webpack_require__(37);
+var BigNumber    = __webpack_require__(38);
+var Buffer       = __webpack_require__(1).Buffer;
+var BufferList   = __webpack_require__(40);
+
+var MAX_PACKET_LENGTH    = Math.pow(2, 24) - 1;
+var MUL_32BIT            = Math.pow(2, 32);
+var PACKET_HEADER_LENGTH = 4;
 
 module.exports = Parser;
 function Parser(options) {
@@ -6150,71 +6522,17 @@ Parser.prototype.write = function write(chunk) {
   this._nextBuffers.push(chunk);
 
   while (!this._paused) {
-    if (!this._packetHeader) {
-      if (!this._combineNextBuffers(4)) {
-        break;
-      }
+    var packetHeader = this._tryReadPacketHeader();
 
-      this._packetHeader = new PacketHeader(
-        this.parseUnsignedNumber(3),
-        this.parseUnsignedNumber(1)
-      );
-
-      if (this._packetHeader.number !== this._nextPacketNumber) {
-        var err = new Error(
-          'Packets out of order. Got: ' + this._packetHeader.number + ' ' +
-          'Expected: ' + this._nextPacketNumber
-        );
-
-        err.code  = 'PROTOCOL_PACKETS_OUT_OF_ORDER';
-        err.fatal = true;
-
-        this._onError(err);
-      }
-
-      this.incrementPacketNumber();
-    }
-
-    if (!this._combineNextBuffers(this._packetHeader.length)) {
+    if (!packetHeader) {
       break;
     }
 
-    this._packetEnd    = this._offset + this._packetHeader.length;
-    this._packetOffset = this._offset;
-
-    if (this._packetHeader.length === MAX_PACKET_LENGTH) {
-      this._longPacketBuffers.push(this._buffer.slice(this._packetOffset, this._packetEnd));
-
-      this._advanceToNextPacket();
-      continue;
+    if (!this._combineNextBuffers(packetHeader.length)) {
+      break;
     }
 
-    this._combineLongPacketBuffers();
-
-    // Try...finally to ensure exception safety. Unfortunately this is costing
-    // us up to ~10% performance in some benchmarks.
-    var hadException = true;
-    try {
-      this._onPacket(this._packetHeader);
-      hadException = false;
-    } catch (err) {
-      if (!err || typeof err.code !== 'string' || err.code.substr(0, 7) !== 'PARSER_') {
-        throw err; // Rethrow non-MySQL errors
-      }
-
-      // Pass down parser errors
-      this._onError(err);
-      hadException = false;
-    } finally {
-      this._advanceToNextPacket();
-
-      // If we had an exception, the parser while loop will be broken out
-      // of after the finally block. So we need to make sure to re-enter it
-      // to continue parsing any bytes that may already have been received.
-      if (hadException) {
-        process.nextTick(this.write.bind(this));
-      }
-    }
+    this._parsePacket(packetHeader);
   }
 };
 
@@ -6289,8 +6607,8 @@ Parser.prototype.resume = function() {
   process.nextTick(this.write.bind(this));
 };
 
-Parser.prototype.peak = function() {
-  return this._buffer[this._offset];
+Parser.prototype.peak = function peak(offset) {
+  return this._buffer[this._offset + (offset >>> 0)];
 };
 
 Parser.prototype.parseUnsignedNumber = function parseUnsignedNumber(bytes) {
@@ -6374,7 +6692,7 @@ Parser.prototype.parseLengthCodedNumber = function parseLengthCodedNumber() {
   var value;
 
   if (high >>> 21) {
-    value = (new BigNumber(low)).plus((new BigNumber(MUL_32BIT)).times(high)).toString();
+    value = BigNumber(MUL_32BIT).times(high).plus(low).toString();
 
     if (this._supportBigNumbers) {
       return value;
@@ -6590,6 +6908,73 @@ Parser.prototype._combineLongPacketBuffers = function _combineLongPacketBuffers(
   this._packetOffset = 0;
 };
 
+Parser.prototype._parsePacket = function _parsePacket(packetHeader) {
+  this._packetEnd    = this._offset + packetHeader.length;
+  this._packetOffset = this._offset;
+
+  if (packetHeader.length === MAX_PACKET_LENGTH) {
+    this._longPacketBuffers.push(this._buffer.slice(this._packetOffset, this._packetEnd));
+    this._advanceToNextPacket();
+    return;
+  }
+
+  this._combineLongPacketBuffers();
+
+  var hadException = true;
+  try {
+    this._onPacket(packetHeader);
+    hadException = false;
+  } catch (err) {
+    if (!err || typeof err.code !== 'string' || err.code.substr(0, 7) !== 'PARSER_') {
+      throw err; // Rethrow non-MySQL errors
+    }
+
+    // Pass down parser errors
+    this._onError(err);
+    hadException = false;
+  } finally {
+    this._advanceToNextPacket();
+
+    // If there was an exception, the parser while loop will be broken out
+    // of after the finally block. So schedule a blank write to re-enter it
+    // to continue parsing any bytes that may already have been received.
+    if (hadException) {
+      process.nextTick(this.write.bind(this));
+    }
+  }
+};
+
+Parser.prototype._tryReadPacketHeader = function _tryReadPacketHeader() {
+  if (this._packetHeader) {
+    return this._packetHeader;
+  }
+
+  if (!this._combineNextBuffers(PACKET_HEADER_LENGTH)) {
+    return null;
+  }
+
+  this._packetHeader = new PacketHeader(
+    this.parseUnsignedNumber(3),
+    this.parseUnsignedNumber(1)
+  );
+
+  if (this._packetHeader.number !== this._nextPacketNumber) {
+    var err = new Error(
+      'Packets out of order. Got: ' + this._packetHeader.number + ' ' +
+      'Expected: ' + this._nextPacketNumber
+    );
+
+    err.code  = 'PROTOCOL_PACKETS_OUT_OF_ORDER';
+    err.fatal = true;
+
+    this._onError(err);
+  }
+
+  this.incrementPacketNumber();
+
+  return this._packetHeader;
+};
+
 Parser.prototype._advanceToNextPacket = function() {
   this._offset       = this._packetEnd;
   this._packetHeader = null;
@@ -6611,2736 +6996,2804 @@ function PacketHeader(length, number) {
 
 /***/ }),
 /* 38 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_RESULT__;/*! bignumber.js v4.0.4 https://github.com/MikeMcl/bignumber.js/LICENCE */
-
-;(function (globalObj) {
-    'use strict';
-
-    /*
-      bignumber.js v4.0.4
-      A JavaScript library for arbitrary-precision arithmetic.
-      https://github.com/MikeMcl/bignumber.js
-      Copyright (c) 2017 Michael Mclaughlin <M8ch88l@gmail.com>
-      MIT Expat Licence
-    */
-
-
-    var BigNumber,
-        isNumeric = /^-?(\d+(\.\d*)?|\.\d+)(e[+-]?\d+)?$/i,
-        mathceil = Math.ceil,
-        mathfloor = Math.floor,
-        notBool = ' not a boolean or binary digit',
-        roundingMode = 'rounding mode',
-        tooManyDigits = 'number type has more than 15 significant digits',
-        ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_',
-        BASE = 1e14,
-        LOG_BASE = 14,
-        MAX_SAFE_INTEGER = 0x1fffffffffffff,         // 2^53 - 1
-        // MAX_INT32 = 0x7fffffff,                   // 2^31 - 1
-        POWS_TEN = [1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13],
-        SQRT_BASE = 1e7,
-
-        /*
-         * The limit on the value of DECIMAL_PLACES, TO_EXP_NEG, TO_EXP_POS, MIN_EXP, MAX_EXP, and
-         * the arguments to toExponential, toFixed, toFormat, and toPrecision, beyond which an
-         * exception is thrown (if ERRORS is true).
-         */
-        MAX = 1E9;                                   // 0 to MAX_INT32
-
-
-    /*
-     * Create and return a BigNumber constructor.
-     */
-    function constructorFactory(config) {
-        var div, parseNumeric,
-
-            // id tracks the caller function, so its name can be included in error messages.
-            id = 0,
-            P = BigNumber.prototype,
-            ONE = new BigNumber(1),
-
-
-            /********************************* EDITABLE DEFAULTS **********************************/
-
-
-            /*
-             * The default values below must be integers within the inclusive ranges stated.
-             * The values can also be changed at run-time using BigNumber.config.
-             */
-
-            // The maximum number of decimal places for operations involving division.
-            DECIMAL_PLACES = 20,                     // 0 to MAX
-
-            /*
-             * The rounding mode used when rounding to the above decimal places, and when using
-             * toExponential, toFixed, toFormat and toPrecision, and round (default value).
-             * UP         0 Away from zero.
-             * DOWN       1 Towards zero.
-             * CEIL       2 Towards +Infinity.
-             * FLOOR      3 Towards -Infinity.
-             * HALF_UP    4 Towards nearest neighbour. If equidistant, up.
-             * HALF_DOWN  5 Towards nearest neighbour. If equidistant, down.
-             * HALF_EVEN  6 Towards nearest neighbour. If equidistant, towards even neighbour.
-             * HALF_CEIL  7 Towards nearest neighbour. If equidistant, towards +Infinity.
-             * HALF_FLOOR 8 Towards nearest neighbour. If equidistant, towards -Infinity.
-             */
-            ROUNDING_MODE = 4,                       // 0 to 8
-
-            // EXPONENTIAL_AT : [TO_EXP_NEG , TO_EXP_POS]
-
-            // The exponent value at and beneath which toString returns exponential notation.
-            // Number type: -7
-            TO_EXP_NEG = -7,                         // 0 to -MAX
-
-            // The exponent value at and above which toString returns exponential notation.
-            // Number type: 21
-            TO_EXP_POS = 21,                         // 0 to MAX
-
-            // RANGE : [MIN_EXP, MAX_EXP]
-
-            // The minimum exponent value, beneath which underflow to zero occurs.
-            // Number type: -324  (5e-324)
-            MIN_EXP = -1e7,                          // -1 to -MAX
-
-            // The maximum exponent value, above which overflow to Infinity occurs.
-            // Number type:  308  (1.7976931348623157e+308)
-            // For MAX_EXP > 1e7, e.g. new BigNumber('1e100000000').plus(1) may be slow.
-            MAX_EXP = 1e7,                           // 1 to MAX
-
-            // Whether BigNumber Errors are ever thrown.
-            ERRORS = true,                           // true or false
-
-            // Change to intValidatorNoErrors if ERRORS is false.
-            isValidInt = intValidatorWithErrors,     // intValidatorWithErrors/intValidatorNoErrors
-
-            // Whether to use cryptographically-secure random number generation, if available.
-            CRYPTO = false,                          // true or false
-
-            /*
-             * The modulo mode used when calculating the modulus: a mod n.
-             * The quotient (q = a / n) is calculated according to the corresponding rounding mode.
-             * The remainder (r) is calculated as: r = a - n * q.
-             *
-             * UP        0 The remainder is positive if the dividend is negative, else is negative.
-             * DOWN      1 The remainder has the same sign as the dividend.
-             *             This modulo mode is commonly known as 'truncated division' and is
-             *             equivalent to (a % n) in JavaScript.
-             * FLOOR     3 The remainder has the same sign as the divisor (Python %).
-             * HALF_EVEN 6 This modulo mode implements the IEEE 754 remainder function.
-             * EUCLID    9 Euclidian division. q = sign(n) * floor(a / abs(n)).
-             *             The remainder is always positive.
-             *
-             * The truncated division, floored division, Euclidian division and IEEE 754 remainder
-             * modes are commonly used for the modulus operation.
-             * Although the other rounding modes can also be used, they may not give useful results.
-             */
-            MODULO_MODE = 1,                         // 0 to 9
-
-            // The maximum number of significant digits of the result of the toPower operation.
-            // If POW_PRECISION is 0, there will be unlimited significant digits.
-            POW_PRECISION = 0,                       // 0 to MAX
-
-            // The format specification used by the BigNumber.prototype.toFormat method.
-            FORMAT = {
-                decimalSeparator: '.',
-                groupSeparator: ',',
-                groupSize: 3,
-                secondaryGroupSize: 0,
-                fractionGroupSeparator: '\xA0',      // non-breaking space
-                fractionGroupSize: 0
-            };
-
-
-        /******************************************************************************************/
-
-
-        // CONSTRUCTOR
-
-
-        /*
-         * The BigNumber constructor and exported function.
-         * Create and return a new instance of a BigNumber object.
-         *
-         * n {number|string|BigNumber} A numeric value.
-         * [b] {number} The base of n. Integer, 2 to 64 inclusive.
-         */
-        function BigNumber( n, b ) {
-            var c, e, i, num, len, str,
-                x = this;
-
-            // Enable constructor usage without new.
-            if ( !( x instanceof BigNumber ) ) {
-
-                // 'BigNumber() constructor call without new: {n}'
-                if (ERRORS) raise( 26, 'constructor call without new', n );
-                return new BigNumber( n, b );
-            }
-
-            // 'new BigNumber() base not an integer: {b}'
-            // 'new BigNumber() base out of range: {b}'
-            if ( b == null || !isValidInt( b, 2, 64, id, 'base' ) ) {
-
-                // Duplicate.
-                if ( n instanceof BigNumber ) {
-                    x.s = n.s;
-                    x.e = n.e;
-                    x.c = ( n = n.c ) ? n.slice() : n;
-                    id = 0;
-                    return;
-                }
-
-                if ( ( num = typeof n == 'number' ) && n * 0 == 0 ) {
-                    x.s = 1 / n < 0 ? ( n = -n, -1 ) : 1;
-
-                    // Fast path for integers.
-                    if ( n === ~~n ) {
-                        for ( e = 0, i = n; i >= 10; i /= 10, e++ );
-                        x.e = e;
-                        x.c = [n];
-                        id = 0;
-                        return;
-                    }
-
-                    str = n + '';
-                } else {
-                    if ( !isNumeric.test( str = n + '' ) ) return parseNumeric( x, str, num );
-                    x.s = str.charCodeAt(0) === 45 ? ( str = str.slice(1), -1 ) : 1;
-                }
-            } else {
-                b = b | 0;
-                str = n + '';
-
-                // Ensure return value is rounded to DECIMAL_PLACES as with other bases.
-                // Allow exponential notation to be used with base 10 argument.
-                if ( b == 10 ) {
-                    x = new BigNumber( n instanceof BigNumber ? n : str );
-                    return round( x, DECIMAL_PLACES + x.e + 1, ROUNDING_MODE );
-                }
-
-                // Avoid potential interpretation of Infinity and NaN as base 44+ values.
-                // Any number in exponential form will fail due to the [Ee][+-].
-                if ( ( num = typeof n == 'number' ) && n * 0 != 0 ||
-                  !( new RegExp( '^-?' + ( c = '[' + ALPHABET.slice( 0, b ) + ']+' ) +
-                    '(?:\\.' + c + ')?$',b < 37 ? 'i' : '' ) ).test(str) ) {
-                    return parseNumeric( x, str, num, b );
-                }
-
-                if (num) {
-                    x.s = 1 / n < 0 ? ( str = str.slice(1), -1 ) : 1;
-
-                    if ( ERRORS && str.replace( /^0\.0*|\./, '' ).length > 15 ) {
-
-                        // 'new BigNumber() number type has more than 15 significant digits: {n}'
-                        raise( id, tooManyDigits, n );
-                    }
-
-                    // Prevent later check for length on converted number.
-                    num = false;
-                } else {
-                    x.s = str.charCodeAt(0) === 45 ? ( str = str.slice(1), -1 ) : 1;
-                }
-
-                str = convertBase( str, 10, b, x.s );
-            }
-
-            // Decimal point?
-            if ( ( e = str.indexOf('.') ) > -1 ) str = str.replace( '.', '' );
-
-            // Exponential form?
-            if ( ( i = str.search( /e/i ) ) > 0 ) {
-
-                // Determine exponent.
-                if ( e < 0 ) e = i;
-                e += +str.slice( i + 1 );
-                str = str.substring( 0, i );
-            } else if ( e < 0 ) {
-
-                // Integer.
-                e = str.length;
-            }
-
-            // Determine leading zeros.
-            for ( i = 0; str.charCodeAt(i) === 48; i++ );
-
-            // Determine trailing zeros.
-            for ( len = str.length; str.charCodeAt(--len) === 48; );
-            str = str.slice( i, len + 1 );
-
-            if (str) {
-                len = str.length;
-
-                // Disallow numbers with over 15 significant digits if number type.
-                // 'new BigNumber() number type has more than 15 significant digits: {n}'
-                if ( num && ERRORS && len > 15 && ( n > MAX_SAFE_INTEGER || n !== mathfloor(n) ) ) {
-                    raise( id, tooManyDigits, x.s * n );
-                }
-
-                e = e - i - 1;
-
-                 // Overflow?
-                if ( e > MAX_EXP ) {
-
-                    // Infinity.
-                    x.c = x.e = null;
-
-                // Underflow?
-                } else if ( e < MIN_EXP ) {
-
-                    // Zero.
-                    x.c = [ x.e = 0 ];
-                } else {
-                    x.e = e;
-                    x.c = [];
-
-                    // Transform base
-
-                    // e is the base 10 exponent.
-                    // i is where to slice str to get the first element of the coefficient array.
-                    i = ( e + 1 ) % LOG_BASE;
-                    if ( e < 0 ) i += LOG_BASE;
-
-                    if ( i < len ) {
-                        if (i) x.c.push( +str.slice( 0, i ) );
-
-                        for ( len -= LOG_BASE; i < len; ) {
-                            x.c.push( +str.slice( i, i += LOG_BASE ) );
-                        }
-
-                        str = str.slice(i);
-                        i = LOG_BASE - str.length;
-                    } else {
-                        i -= len;
-                    }
-
-                    for ( ; i--; str += '0' );
-                    x.c.push( +str );
-                }
-            } else {
-
-                // Zero.
-                x.c = [ x.e = 0 ];
-            }
-
-            id = 0;
-        }
-
-
-        // CONSTRUCTOR PROPERTIES
-
-
-        BigNumber.another = constructorFactory;
-
-        BigNumber.ROUND_UP = 0;
-        BigNumber.ROUND_DOWN = 1;
-        BigNumber.ROUND_CEIL = 2;
-        BigNumber.ROUND_FLOOR = 3;
-        BigNumber.ROUND_HALF_UP = 4;
-        BigNumber.ROUND_HALF_DOWN = 5;
-        BigNumber.ROUND_HALF_EVEN = 6;
-        BigNumber.ROUND_HALF_CEIL = 7;
-        BigNumber.ROUND_HALF_FLOOR = 8;
-        BigNumber.EUCLID = 9;
-
-
-        /*
-         * Configure infrequently-changing library-wide settings.
-         *
-         * Accept an object or an argument list, with one or many of the following properties or
-         * parameters respectively:
-         *
-         *   DECIMAL_PLACES  {number}  Integer, 0 to MAX inclusive
-         *   ROUNDING_MODE   {number}  Integer, 0 to 8 inclusive
-         *   EXPONENTIAL_AT  {number|number[]}  Integer, -MAX to MAX inclusive or
-         *                                      [integer -MAX to 0 incl., 0 to MAX incl.]
-         *   RANGE           {number|number[]}  Non-zero integer, -MAX to MAX inclusive or
-         *                                      [integer -MAX to -1 incl., integer 1 to MAX incl.]
-         *   ERRORS          {boolean|number}   true, false, 1 or 0
-         *   CRYPTO          {boolean|number}   true, false, 1 or 0
-         *   MODULO_MODE     {number}           0 to 9 inclusive
-         *   POW_PRECISION   {number}           0 to MAX inclusive
-         *   FORMAT          {object}           See BigNumber.prototype.toFormat
-         *      decimalSeparator       {string}
-         *      groupSeparator         {string}
-         *      groupSize              {number}
-         *      secondaryGroupSize     {number}
-         *      fractionGroupSeparator {string}
-         *      fractionGroupSize      {number}
-         *
-         * (The values assigned to the above FORMAT object properties are not checked for validity.)
-         *
-         * E.g.
-         * BigNumber.config(20, 4) is equivalent to
-         * BigNumber.config({ DECIMAL_PLACES : 20, ROUNDING_MODE : 4 })
-         *
-         * Ignore properties/parameters set to null or undefined.
-         * Return an object with the properties current values.
-         */
-        BigNumber.config = BigNumber.set = function () {
-            var v, p,
-                i = 0,
-                r = {},
-                a = arguments,
-                o = a[0],
-                has = o && typeof o == 'object'
-                  ? function () { if ( o.hasOwnProperty(p) ) return ( v = o[p] ) != null; }
-                  : function () { if ( a.length > i ) return ( v = a[i++] ) != null; };
-
-            // DECIMAL_PLACES {number} Integer, 0 to MAX inclusive.
-            // 'config() DECIMAL_PLACES not an integer: {v}'
-            // 'config() DECIMAL_PLACES out of range: {v}'
-            if ( has( p = 'DECIMAL_PLACES' ) && isValidInt( v, 0, MAX, 2, p ) ) {
-                DECIMAL_PLACES = v | 0;
-            }
-            r[p] = DECIMAL_PLACES;
-
-            // ROUNDING_MODE {number} Integer, 0 to 8 inclusive.
-            // 'config() ROUNDING_MODE not an integer: {v}'
-            // 'config() ROUNDING_MODE out of range: {v}'
-            if ( has( p = 'ROUNDING_MODE' ) && isValidInt( v, 0, 8, 2, p ) ) {
-                ROUNDING_MODE = v | 0;
-            }
-            r[p] = ROUNDING_MODE;
-
-            // EXPONENTIAL_AT {number|number[]}
-            // Integer, -MAX to MAX inclusive or [integer -MAX to 0 inclusive, 0 to MAX inclusive].
-            // 'config() EXPONENTIAL_AT not an integer: {v}'
-            // 'config() EXPONENTIAL_AT out of range: {v}'
-            if ( has( p = 'EXPONENTIAL_AT' ) ) {
-
-                if ( isArray(v) ) {
-                    if ( isValidInt( v[0], -MAX, 0, 2, p ) && isValidInt( v[1], 0, MAX, 2, p ) ) {
-                        TO_EXP_NEG = v[0] | 0;
-                        TO_EXP_POS = v[1] | 0;
-                    }
-                } else if ( isValidInt( v, -MAX, MAX, 2, p ) ) {
-                    TO_EXP_NEG = -( TO_EXP_POS = ( v < 0 ? -v : v ) | 0 );
-                }
-            }
-            r[p] = [ TO_EXP_NEG, TO_EXP_POS ];
-
-            // RANGE {number|number[]} Non-zero integer, -MAX to MAX inclusive or
-            // [integer -MAX to -1 inclusive, integer 1 to MAX inclusive].
-            // 'config() RANGE not an integer: {v}'
-            // 'config() RANGE cannot be zero: {v}'
-            // 'config() RANGE out of range: {v}'
-            if ( has( p = 'RANGE' ) ) {
-
-                if ( isArray(v) ) {
-                    if ( isValidInt( v[0], -MAX, -1, 2, p ) && isValidInt( v[1], 1, MAX, 2, p ) ) {
-                        MIN_EXP = v[0] | 0;
-                        MAX_EXP = v[1] | 0;
-                    }
-                } else if ( isValidInt( v, -MAX, MAX, 2, p ) ) {
-                    if ( v | 0 ) MIN_EXP = -( MAX_EXP = ( v < 0 ? -v : v ) | 0 );
-                    else if (ERRORS) raise( 2, p + ' cannot be zero', v );
-                }
-            }
-            r[p] = [ MIN_EXP, MAX_EXP ];
-
-            // ERRORS {boolean|number} true, false, 1 or 0.
-            // 'config() ERRORS not a boolean or binary digit: {v}'
-            if ( has( p = 'ERRORS' ) ) {
-
-                if ( v === !!v || v === 1 || v === 0 ) {
-                    id = 0;
-                    isValidInt = ( ERRORS = !!v ) ? intValidatorWithErrors : intValidatorNoErrors;
-                } else if (ERRORS) {
-                    raise( 2, p + notBool, v );
-                }
-            }
-            r[p] = ERRORS;
-
-            // CRYPTO {boolean|number} true, false, 1 or 0.
-            // 'config() CRYPTO not a boolean or binary digit: {v}'
-            // 'config() crypto unavailable: {crypto}'
-            if ( has( p = 'CRYPTO' ) ) {
-
-                if ( v === true || v === false || v === 1 || v === 0 ) {
-                    if (v) {
-                        v = typeof crypto == 'undefined';
-                        if ( !v && crypto && (crypto.getRandomValues || crypto.randomBytes)) {
-                            CRYPTO = true;
-                        } else if (ERRORS) {
-                            raise( 2, 'crypto unavailable', v ? void 0 : crypto );
-                        } else {
-                            CRYPTO = false;
-                        }
-                    } else {
-                        CRYPTO = false;
-                    }
-                } else if (ERRORS) {
-                    raise( 2, p + notBool, v );
-                }
-            }
-            r[p] = CRYPTO;
-
-            // MODULO_MODE {number} Integer, 0 to 9 inclusive.
-            // 'config() MODULO_MODE not an integer: {v}'
-            // 'config() MODULO_MODE out of range: {v}'
-            if ( has( p = 'MODULO_MODE' ) && isValidInt( v, 0, 9, 2, p ) ) {
-                MODULO_MODE = v | 0;
-            }
-            r[p] = MODULO_MODE;
-
-            // POW_PRECISION {number} Integer, 0 to MAX inclusive.
-            // 'config() POW_PRECISION not an integer: {v}'
-            // 'config() POW_PRECISION out of range: {v}'
-            if ( has( p = 'POW_PRECISION' ) && isValidInt( v, 0, MAX, 2, p ) ) {
-                POW_PRECISION = v | 0;
-            }
-            r[p] = POW_PRECISION;
-
-            // FORMAT {object}
-            // 'config() FORMAT not an object: {v}'
-            if ( has( p = 'FORMAT' ) ) {
-
-                if ( typeof v == 'object' ) {
-                    FORMAT = v;
-                } else if (ERRORS) {
-                    raise( 2, p + ' not an object', v );
-                }
-            }
-            r[p] = FORMAT;
-
-            return r;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the maximum of the arguments.
-         *
-         * arguments {number|string|BigNumber}
-         */
-        BigNumber.max = function () { return maxOrMin( arguments, P.lt ); };
-
-
-        /*
-         * Return a new BigNumber whose value is the minimum of the arguments.
-         *
-         * arguments {number|string|BigNumber}
-         */
-        BigNumber.min = function () { return maxOrMin( arguments, P.gt ); };
-
-
-        /*
-         * Return a new BigNumber with a random value equal to or greater than 0 and less than 1,
-         * and with dp, or DECIMAL_PLACES if dp is omitted, decimal places (or less if trailing
-         * zeros are produced).
-         *
-         * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
-         *
-         * 'random() decimal places not an integer: {dp}'
-         * 'random() decimal places out of range: {dp}'
-         * 'random() crypto unavailable: {crypto}'
-         */
-        BigNumber.random = (function () {
-            var pow2_53 = 0x20000000000000;
-
-            // Return a 53 bit integer n, where 0 <= n < 9007199254740992.
-            // Check if Math.random() produces more than 32 bits of randomness.
-            // If it does, assume at least 53 bits are produced, otherwise assume at least 30 bits.
-            // 0x40000000 is 2^30, 0x800000 is 2^23, 0x1fffff is 2^21 - 1.
-            var random53bitInt = (Math.random() * pow2_53) & 0x1fffff
-              ? function () { return mathfloor( Math.random() * pow2_53 ); }
-              : function () { return ((Math.random() * 0x40000000 | 0) * 0x800000) +
-                  (Math.random() * 0x800000 | 0); };
-
-            return function (dp) {
-                var a, b, e, k, v,
-                    i = 0,
-                    c = [],
-                    rand = new BigNumber(ONE);
-
-                dp = dp == null || !isValidInt( dp, 0, MAX, 14 ) ? DECIMAL_PLACES : dp | 0;
-                k = mathceil( dp / LOG_BASE );
-
-                if (CRYPTO) {
-
-                    // Browsers supporting crypto.getRandomValues.
-                    if (crypto.getRandomValues) {
-
-                        a = crypto.getRandomValues( new Uint32Array( k *= 2 ) );
-
-                        for ( ; i < k; ) {
-
-                            // 53 bits:
-                            // ((Math.pow(2, 32) - 1) * Math.pow(2, 21)).toString(2)
-                            // 11111 11111111 11111111 11111111 11100000 00000000 00000000
-                            // ((Math.pow(2, 32) - 1) >>> 11).toString(2)
-                            //                                     11111 11111111 11111111
-                            // 0x20000 is 2^21.
-                            v = a[i] * 0x20000 + (a[i + 1] >>> 11);
-
-                            // Rejection sampling:
-                            // 0 <= v < 9007199254740992
-                            // Probability that v >= 9e15, is
-                            // 7199254740992 / 9007199254740992 ~= 0.0008, i.e. 1 in 1251
-                            if ( v >= 9e15 ) {
-                                b = crypto.getRandomValues( new Uint32Array(2) );
-                                a[i] = b[0];
-                                a[i + 1] = b[1];
-                            } else {
-
-                                // 0 <= v <= 8999999999999999
-                                // 0 <= (v % 1e14) <= 99999999999999
-                                c.push( v % 1e14 );
-                                i += 2;
-                            }
-                        }
-                        i = k / 2;
-
-                    // Node.js supporting crypto.randomBytes.
-                    } else if (crypto.randomBytes) {
-
-                        // buffer
-                        a = crypto.randomBytes( k *= 7 );
-
-                        for ( ; i < k; ) {
-
-                            // 0x1000000000000 is 2^48, 0x10000000000 is 2^40
-                            // 0x100000000 is 2^32, 0x1000000 is 2^24
-                            // 11111 11111111 11111111 11111111 11111111 11111111 11111111
-                            // 0 <= v < 9007199254740992
-                            v = ( ( a[i] & 31 ) * 0x1000000000000 ) + ( a[i + 1] * 0x10000000000 ) +
-                                  ( a[i + 2] * 0x100000000 ) + ( a[i + 3] * 0x1000000 ) +
-                                  ( a[i + 4] << 16 ) + ( a[i + 5] << 8 ) + a[i + 6];
-
-                            if ( v >= 9e15 ) {
-                                crypto.randomBytes(7).copy( a, i );
-                            } else {
-
-                                // 0 <= (v % 1e14) <= 99999999999999
-                                c.push( v % 1e14 );
-                                i += 7;
-                            }
-                        }
-                        i = k / 7;
-                    } else {
-                        CRYPTO = false;
-                        if (ERRORS) raise( 14, 'crypto unavailable', crypto );
-                    }
-                }
-
-                // Use Math.random.
-                if (!CRYPTO) {
-
-                    for ( ; i < k; ) {
-                        v = random53bitInt();
-                        if ( v < 9e15 ) c[i++] = v % 1e14;
-                    }
-                }
-
-                k = c[--i];
-                dp %= LOG_BASE;
-
-                // Convert trailing digits to zeros according to dp.
-                if ( k && dp ) {
-                    v = POWS_TEN[LOG_BASE - dp];
-                    c[i] = mathfloor( k / v ) * v;
-                }
-
-                // Remove trailing elements which are zero.
-                for ( ; c[i] === 0; c.pop(), i-- );
-
-                // Zero?
-                if ( i < 0 ) {
-                    c = [ e = 0 ];
-                } else {
-
-                    // Remove leading elements which are zero and adjust exponent accordingly.
-                    for ( e = -1 ; c[0] === 0; c.splice(0, 1), e -= LOG_BASE);
-
-                    // Count the digits of the first element of c to determine leading zeros, and...
-                    for ( i = 1, v = c[0]; v >= 10; v /= 10, i++);
-
-                    // adjust the exponent accordingly.
-                    if ( i < LOG_BASE ) e -= LOG_BASE - i;
-                }
-
-                rand.e = e;
-                rand.c = c;
-                return rand;
-            };
-        })();
-
-
-        // PRIVATE FUNCTIONS
-
-
-        // Convert a numeric string of baseIn to a numeric string of baseOut.
-        function convertBase( str, baseOut, baseIn, sign ) {
-            var d, e, k, r, x, xc, y,
-                i = str.indexOf( '.' ),
-                dp = DECIMAL_PLACES,
-                rm = ROUNDING_MODE;
-
-            if ( baseIn < 37 ) str = str.toLowerCase();
-
-            // Non-integer.
-            if ( i >= 0 ) {
-                k = POW_PRECISION;
-
-                // Unlimited precision.
-                POW_PRECISION = 0;
-                str = str.replace( '.', '' );
-                y = new BigNumber(baseIn);
-                x = y.pow( str.length - i );
-                POW_PRECISION = k;
-
-                // Convert str as if an integer, then restore the fraction part by dividing the
-                // result by its base raised to a power.
-                y.c = toBaseOut( toFixedPoint( coeffToString( x.c ), x.e ), 10, baseOut );
-                y.e = y.c.length;
-            }
-
-            // Convert the number as integer.
-            xc = toBaseOut( str, baseIn, baseOut );
-            e = k = xc.length;
-
-            // Remove trailing zeros.
-            for ( ; xc[--k] == 0; xc.pop() );
-            if ( !xc[0] ) return '0';
-
-            if ( i < 0 ) {
-                --e;
-            } else {
-                x.c = xc;
-                x.e = e;
-
-                // sign is needed for correct rounding.
-                x.s = sign;
-                x = div( x, y, dp, rm, baseOut );
-                xc = x.c;
-                r = x.r;
-                e = x.e;
-            }
-
-            d = e + dp + 1;
-
-            // The rounding digit, i.e. the digit to the right of the digit that may be rounded up.
-            i = xc[d];
-            k = baseOut / 2;
-            r = r || d < 0 || xc[d + 1] != null;
-
-            r = rm < 4 ? ( i != null || r ) && ( rm == 0 || rm == ( x.s < 0 ? 3 : 2 ) )
-                       : i > k || i == k &&( rm == 4 || r || rm == 6 && xc[d - 1] & 1 ||
-                         rm == ( x.s < 0 ? 8 : 7 ) );
-
-            if ( d < 1 || !xc[0] ) {
-
-                // 1^-dp or 0.
-                str = r ? toFixedPoint( '1', -dp ) : '0';
-            } else {
-                xc.length = d;
-
-                if (r) {
-
-                    // Rounding up may mean the previous digit has to be rounded up and so on.
-                    for ( --baseOut; ++xc[--d] > baseOut; ) {
-                        xc[d] = 0;
-
-                        if ( !d ) {
-                            ++e;
-                            xc = [1].concat(xc);
-                        }
-                    }
-                }
-
-                // Determine trailing zeros.
-                for ( k = xc.length; !xc[--k]; );
-
-                // E.g. [4, 11, 15] becomes 4bf.
-                for ( i = 0, str = ''; i <= k; str += ALPHABET.charAt( xc[i++] ) );
-                str = toFixedPoint( str, e );
-            }
-
-            // The caller will add the sign.
-            return str;
-        }
-
-
-        // Perform division in the specified base. Called by div and convertBase.
-        div = (function () {
-
-            // Assume non-zero x and k.
-            function multiply( x, k, base ) {
-                var m, temp, xlo, xhi,
-                    carry = 0,
-                    i = x.length,
-                    klo = k % SQRT_BASE,
-                    khi = k / SQRT_BASE | 0;
-
-                for ( x = x.slice(); i--; ) {
-                    xlo = x[i] % SQRT_BASE;
-                    xhi = x[i] / SQRT_BASE | 0;
-                    m = khi * xlo + xhi * klo;
-                    temp = klo * xlo + ( ( m % SQRT_BASE ) * SQRT_BASE ) + carry;
-                    carry = ( temp / base | 0 ) + ( m / SQRT_BASE | 0 ) + khi * xhi;
-                    x[i] = temp % base;
-                }
-
-                if (carry) x = [carry].concat(x);
-
-                return x;
-            }
-
-            function compare( a, b, aL, bL ) {
-                var i, cmp;
-
-                if ( aL != bL ) {
-                    cmp = aL > bL ? 1 : -1;
-                } else {
-
-                    for ( i = cmp = 0; i < aL; i++ ) {
-
-                        if ( a[i] != b[i] ) {
-                            cmp = a[i] > b[i] ? 1 : -1;
-                            break;
-                        }
-                    }
-                }
-                return cmp;
-            }
-
-            function subtract( a, b, aL, base ) {
-                var i = 0;
-
-                // Subtract b from a.
-                for ( ; aL--; ) {
-                    a[aL] -= i;
-                    i = a[aL] < b[aL] ? 1 : 0;
-                    a[aL] = i * base + a[aL] - b[aL];
-                }
-
-                // Remove leading zeros.
-                for ( ; !a[0] && a.length > 1; a.splice(0, 1) );
-            }
-
-            // x: dividend, y: divisor.
-            return function ( x, y, dp, rm, base ) {
-                var cmp, e, i, more, n, prod, prodL, q, qc, rem, remL, rem0, xi, xL, yc0,
-                    yL, yz,
-                    s = x.s == y.s ? 1 : -1,
-                    xc = x.c,
-                    yc = y.c;
-
-                // Either NaN, Infinity or 0?
-                if ( !xc || !xc[0] || !yc || !yc[0] ) {
-
-                    return new BigNumber(
-
-                      // Return NaN if either NaN, or both Infinity or 0.
-                      !x.s || !y.s || ( xc ? yc && xc[0] == yc[0] : !yc ) ? NaN :
-
-                        // Return ±0 if x is ±0 or y is ±Infinity, or return ±Infinity as y is ±0.
-                        xc && xc[0] == 0 || !yc ? s * 0 : s / 0
-                    );
-                }
-
-                q = new BigNumber(s);
-                qc = q.c = [];
-                e = x.e - y.e;
-                s = dp + e + 1;
-
-                if ( !base ) {
-                    base = BASE;
-                    e = bitFloor( x.e / LOG_BASE ) - bitFloor( y.e / LOG_BASE );
-                    s = s / LOG_BASE | 0;
-                }
-
-                // Result exponent may be one less then the current value of e.
-                // The coefficients of the BigNumbers from convertBase may have trailing zeros.
-                for ( i = 0; yc[i] == ( xc[i] || 0 ); i++ );
-                if ( yc[i] > ( xc[i] || 0 ) ) e--;
-
-                if ( s < 0 ) {
-                    qc.push(1);
-                    more = true;
-                } else {
-                    xL = xc.length;
-                    yL = yc.length;
-                    i = 0;
-                    s += 2;
-
-                    // Normalise xc and yc so highest order digit of yc is >= base / 2.
-
-                    n = mathfloor( base / ( yc[0] + 1 ) );
-
-                    // Not necessary, but to handle odd bases where yc[0] == ( base / 2 ) - 1.
-                    // if ( n > 1 || n++ == 1 && yc[0] < base / 2 ) {
-                    if ( n > 1 ) {
-                        yc = multiply( yc, n, base );
-                        xc = multiply( xc, n, base );
-                        yL = yc.length;
-                        xL = xc.length;
-                    }
-
-                    xi = yL;
-                    rem = xc.slice( 0, yL );
-                    remL = rem.length;
-
-                    // Add zeros to make remainder as long as divisor.
-                    for ( ; remL < yL; rem[remL++] = 0 );
-                    yz = yc.slice();
-                    yz = [0].concat(yz);
-                    yc0 = yc[0];
-                    if ( yc[1] >= base / 2 ) yc0++;
-                    // Not necessary, but to prevent trial digit n > base, when using base 3.
-                    // else if ( base == 3 && yc0 == 1 ) yc0 = 1 + 1e-15;
-
-                    do {
-                        n = 0;
-
-                        // Compare divisor and remainder.
-                        cmp = compare( yc, rem, yL, remL );
-
-                        // If divisor < remainder.
-                        if ( cmp < 0 ) {
-
-                            // Calculate trial digit, n.
-
-                            rem0 = rem[0];
-                            if ( yL != remL ) rem0 = rem0 * base + ( rem[1] || 0 );
-
-                            // n is how many times the divisor goes into the current remainder.
-                            n = mathfloor( rem0 / yc0 );
-
-                            //  Algorithm:
-                            //  1. product = divisor * trial digit (n)
-                            //  2. if product > remainder: product -= divisor, n--
-                            //  3. remainder -= product
-                            //  4. if product was < remainder at 2:
-                            //    5. compare new remainder and divisor
-                            //    6. If remainder > divisor: remainder -= divisor, n++
-
-                            if ( n > 1 ) {
-
-                                // n may be > base only when base is 3.
-                                if (n >= base) n = base - 1;
-
-                                // product = divisor * trial digit.
-                                prod = multiply( yc, n, base );
-                                prodL = prod.length;
-                                remL = rem.length;
-
-                                // Compare product and remainder.
-                                // If product > remainder.
-                                // Trial digit n too high.
-                                // n is 1 too high about 5% of the time, and is not known to have
-                                // ever been more than 1 too high.
-                                while ( compare( prod, rem, prodL, remL ) == 1 ) {
-                                    n--;
-
-                                    // Subtract divisor from product.
-                                    subtract( prod, yL < prodL ? yz : yc, prodL, base );
-                                    prodL = prod.length;
-                                    cmp = 1;
-                                }
-                            } else {
-
-                                // n is 0 or 1, cmp is -1.
-                                // If n is 0, there is no need to compare yc and rem again below,
-                                // so change cmp to 1 to avoid it.
-                                // If n is 1, leave cmp as -1, so yc and rem are compared again.
-                                if ( n == 0 ) {
-
-                                    // divisor < remainder, so n must be at least 1.
-                                    cmp = n = 1;
-                                }
-
-                                // product = divisor
-                                prod = yc.slice();
-                                prodL = prod.length;
-                            }
-
-                            if ( prodL < remL ) prod = [0].concat(prod);
-
-                            // Subtract product from remainder.
-                            subtract( rem, prod, remL, base );
-                            remL = rem.length;
-
-                             // If product was < remainder.
-                            if ( cmp == -1 ) {
-
-                                // Compare divisor and new remainder.
-                                // If divisor < new remainder, subtract divisor from remainder.
-                                // Trial digit n too low.
-                                // n is 1 too low about 5% of the time, and very rarely 2 too low.
-                                while ( compare( yc, rem, yL, remL ) < 1 ) {
-                                    n++;
-
-                                    // Subtract divisor from remainder.
-                                    subtract( rem, yL < remL ? yz : yc, remL, base );
-                                    remL = rem.length;
-                                }
-                            }
-                        } else if ( cmp === 0 ) {
-                            n++;
-                            rem = [0];
-                        } // else cmp === 1 and n will be 0
-
-                        // Add the next digit, n, to the result array.
-                        qc[i++] = n;
-
-                        // Update the remainder.
-                        if ( rem[0] ) {
-                            rem[remL++] = xc[xi] || 0;
-                        } else {
-                            rem = [ xc[xi] ];
-                            remL = 1;
-                        }
-                    } while ( ( xi++ < xL || rem[0] != null ) && s-- );
-
-                    more = rem[0] != null;
-
-                    // Leading zero?
-                    if ( !qc[0] ) qc.splice(0, 1);
-                }
-
-                if ( base == BASE ) {
-
-                    // To calculate q.e, first get the number of digits of qc[0].
-                    for ( i = 1, s = qc[0]; s >= 10; s /= 10, i++ );
-                    round( q, dp + ( q.e = i + e * LOG_BASE - 1 ) + 1, rm, more );
-
-                // Caller is convertBase.
-                } else {
-                    q.e = e;
-                    q.r = +more;
-                }
-
-                return q;
-            };
-        })();
-
-
-        /*
-         * Return a string representing the value of BigNumber n in fixed-point or exponential
-         * notation rounded to the specified decimal places or significant digits.
-         *
-         * n is a BigNumber.
-         * i is the index of the last digit required (i.e. the digit that may be rounded up).
-         * rm is the rounding mode.
-         * caller is caller id: toExponential 19, toFixed 20, toFormat 21, toPrecision 24.
-         */
-        function format( n, i, rm, caller ) {
-            var c0, e, ne, len, str;
-
-            rm = rm != null && isValidInt( rm, 0, 8, caller, roundingMode )
-              ? rm | 0 : ROUNDING_MODE;
-
-            if ( !n.c ) return n.toString();
-            c0 = n.c[0];
-            ne = n.e;
-
-            if ( i == null ) {
-                str = coeffToString( n.c );
-                str = caller == 19 || caller == 24 && ne <= TO_EXP_NEG
-                  ? toExponential( str, ne )
-                  : toFixedPoint( str, ne );
-            } else {
-                n = round( new BigNumber(n), i, rm );
-
-                // n.e may have changed if the value was rounded up.
-                e = n.e;
-
-                str = coeffToString( n.c );
-                len = str.length;
-
-                // toPrecision returns exponential notation if the number of significant digits
-                // specified is less than the number of digits necessary to represent the integer
-                // part of the value in fixed-point notation.
-
-                // Exponential notation.
-                if ( caller == 19 || caller == 24 && ( i <= e || e <= TO_EXP_NEG ) ) {
-
-                    // Append zeros?
-                    for ( ; len < i; str += '0', len++ );
-                    str = toExponential( str, e );
-
-                // Fixed-point notation.
-                } else {
-                    i -= ne;
-                    str = toFixedPoint( str, e );
-
-                    // Append zeros?
-                    if ( e + 1 > len ) {
-                        if ( --i > 0 ) for ( str += '.'; i--; str += '0' );
-                    } else {
-                        i += e - len;
-                        if ( i > 0 ) {
-                            if ( e + 1 == len ) str += '.';
-                            for ( ; i--; str += '0' );
-                        }
-                    }
-                }
-            }
-
-            return n.s < 0 && c0 ? '-' + str : str;
-        }
-
-
-        // Handle BigNumber.max and BigNumber.min.
-        function maxOrMin( args, method ) {
-            var m, n,
-                i = 0;
-
-            if ( isArray( args[0] ) ) args = args[0];
-            m = new BigNumber( args[0] );
-
-            for ( ; ++i < args.length; ) {
-                n = new BigNumber( args[i] );
-
-                // If any number is NaN, return NaN.
-                if ( !n.s ) {
-                    m = n;
-                    break;
-                } else if ( method.call( m, n ) ) {
-                    m = n;
-                }
-            }
-
-            return m;
-        }
-
-
-        /*
-         * Return true if n is an integer in range, otherwise throw.
-         * Use for argument validation when ERRORS is true.
-         */
-        function intValidatorWithErrors( n, min, max, caller, name ) {
-            if ( n < min || n > max || n != truncate(n) ) {
-                raise( caller, ( name || 'decimal places' ) +
-                  ( n < min || n > max ? ' out of range' : ' not an integer' ), n );
-            }
-
-            return true;
-        }
-
-
-        /*
-         * Strip trailing zeros, calculate base 10 exponent and check against MIN_EXP and MAX_EXP.
-         * Called by minus, plus and times.
-         */
-        function normalise( n, c, e ) {
-            var i = 1,
-                j = c.length;
-
-             // Remove trailing zeros.
-            for ( ; !c[--j]; c.pop() );
-
-            // Calculate the base 10 exponent. First get the number of digits of c[0].
-            for ( j = c[0]; j >= 10; j /= 10, i++ );
-
-            // Overflow?
-            if ( ( e = i + e * LOG_BASE - 1 ) > MAX_EXP ) {
-
-                // Infinity.
-                n.c = n.e = null;
-
-            // Underflow?
-            } else if ( e < MIN_EXP ) {
-
-                // Zero.
-                n.c = [ n.e = 0 ];
-            } else {
-                n.e = e;
-                n.c = c;
-            }
-
-            return n;
-        }
-
-
-        // Handle values that fail the validity test in BigNumber.
-        parseNumeric = (function () {
-            var basePrefix = /^(-?)0([xbo])(?=\w[\w.]*$)/i,
-                dotAfter = /^([^.]+)\.$/,
-                dotBefore = /^\.([^.]+)$/,
-                isInfinityOrNaN = /^-?(Infinity|NaN)$/,
-                whitespaceOrPlus = /^\s*\+(?=[\w.])|^\s+|\s+$/g;
-
-            return function ( x, str, num, b ) {
-                var base,
-                    s = num ? str : str.replace( whitespaceOrPlus, '' );
-
-                // No exception on ±Infinity or NaN.
-                if ( isInfinityOrNaN.test(s) ) {
-                    x.s = isNaN(s) ? null : s < 0 ? -1 : 1;
-                } else {
-                    if ( !num ) {
-
-                        // basePrefix = /^(-?)0([xbo])(?=\w[\w.]*$)/i
-                        s = s.replace( basePrefix, function ( m, p1, p2 ) {
-                            base = ( p2 = p2.toLowerCase() ) == 'x' ? 16 : p2 == 'b' ? 2 : 8;
-                            return !b || b == base ? p1 : m;
-                        });
-
-                        if (b) {
-                            base = b;
-
-                            // E.g. '1.' to '1', '.1' to '0.1'
-                            s = s.replace( dotAfter, '$1' ).replace( dotBefore, '0.$1' );
-                        }
-
-                        if ( str != s ) return new BigNumber( s, base );
-                    }
-
-                    // 'new BigNumber() not a number: {n}'
-                    // 'new BigNumber() not a base {b} number: {n}'
-                    if (ERRORS) raise( id, 'not a' + ( b ? ' base ' + b : '' ) + ' number', str );
-                    x.s = null;
-                }
-
-                x.c = x.e = null;
-                id = 0;
-            }
-        })();
-
-
-        // Throw a BigNumber Error.
-        function raise( caller, msg, val ) {
-            var error = new Error( [
-                'new BigNumber',     // 0
-                'cmp',               // 1
-                'config',            // 2
-                'div',               // 3
-                'divToInt',          // 4
-                'eq',                // 5
-                'gt',                // 6
-                'gte',               // 7
-                'lt',                // 8
-                'lte',               // 9
-                'minus',             // 10
-                'mod',               // 11
-                'plus',              // 12
-                'precision',         // 13
-                'random',            // 14
-                'round',             // 15
-                'shift',             // 16
-                'times',             // 17
-                'toDigits',          // 18
-                'toExponential',     // 19
-                'toFixed',           // 20
-                'toFormat',          // 21
-                'toFraction',        // 22
-                'pow',               // 23
-                'toPrecision',       // 24
-                'toString',          // 25
-                'BigNumber'          // 26
-            ][caller] + '() ' + msg + ': ' + val );
-
-            error.name = 'BigNumber Error';
-            id = 0;
-            throw error;
-        }
-
-
-        /*
-         * Round x to sd significant digits using rounding mode rm. Check for over/under-flow.
-         * If r is truthy, it is known that there are more digits after the rounding digit.
-         */
-        function round( x, sd, rm, r ) {
-            var d, i, j, k, n, ni, rd,
-                xc = x.c,
-                pows10 = POWS_TEN;
-
-            // if x is not Infinity or NaN...
-            if (xc) {
-
-                // rd is the rounding digit, i.e. the digit after the digit that may be rounded up.
-                // n is a base 1e14 number, the value of the element of array x.c containing rd.
-                // ni is the index of n within x.c.
-                // d is the number of digits of n.
-                // i is the index of rd within n including leading zeros.
-                // j is the actual index of rd within n (if < 0, rd is a leading zero).
-                out: {
-
-                    // Get the number of digits of the first element of xc.
-                    for ( d = 1, k = xc[0]; k >= 10; k /= 10, d++ );
-                    i = sd - d;
-
-                    // If the rounding digit is in the first element of xc...
-                    if ( i < 0 ) {
-                        i += LOG_BASE;
-                        j = sd;
-                        n = xc[ ni = 0 ];
-
-                        // Get the rounding digit at index j of n.
-                        rd = n / pows10[ d - j - 1 ] % 10 | 0;
-                    } else {
-                        ni = mathceil( ( i + 1 ) / LOG_BASE );
-
-                        if ( ni >= xc.length ) {
-
-                            if (r) {
-
-                                // Needed by sqrt.
-                                for ( ; xc.length <= ni; xc.push(0) );
-                                n = rd = 0;
-                                d = 1;
-                                i %= LOG_BASE;
-                                j = i - LOG_BASE + 1;
-                            } else {
-                                break out;
-                            }
-                        } else {
-                            n = k = xc[ni];
-
-                            // Get the number of digits of n.
-                            for ( d = 1; k >= 10; k /= 10, d++ );
-
-                            // Get the index of rd within n.
-                            i %= LOG_BASE;
-
-                            // Get the index of rd within n, adjusted for leading zeros.
-                            // The number of leading zeros of n is given by LOG_BASE - d.
-                            j = i - LOG_BASE + d;
-
-                            // Get the rounding digit at index j of n.
-                            rd = j < 0 ? 0 : n / pows10[ d - j - 1 ] % 10 | 0;
-                        }
-                    }
-
-                    r = r || sd < 0 ||
-
-                    // Are there any non-zero digits after the rounding digit?
-                    // The expression  n % pows10[ d - j - 1 ]  returns all digits of n to the right
-                    // of the digit at j, e.g. if n is 908714 and j is 2, the expression gives 714.
-                      xc[ni + 1] != null || ( j < 0 ? n : n % pows10[ d - j - 1 ] );
-
-                    r = rm < 4
-                      ? ( rd || r ) && ( rm == 0 || rm == ( x.s < 0 ? 3 : 2 ) )
-                      : rd > 5 || rd == 5 && ( rm == 4 || r || rm == 6 &&
-
-                        // Check whether the digit to the left of the rounding digit is odd.
-                        ( ( i > 0 ? j > 0 ? n / pows10[ d - j ] : 0 : xc[ni - 1] ) % 10 ) & 1 ||
-                          rm == ( x.s < 0 ? 8 : 7 ) );
-
-                    if ( sd < 1 || !xc[0] ) {
-                        xc.length = 0;
-
-                        if (r) {
-
-                            // Convert sd to decimal places.
-                            sd -= x.e + 1;
-
-                            // 1, 0.1, 0.01, 0.001, 0.0001 etc.
-                            xc[0] = pows10[ ( LOG_BASE - sd % LOG_BASE ) % LOG_BASE ];
-                            x.e = -sd || 0;
-                        } else {
-
-                            // Zero.
-                            xc[0] = x.e = 0;
-                        }
-
-                        return x;
-                    }
-
-                    // Remove excess digits.
-                    if ( i == 0 ) {
-                        xc.length = ni;
-                        k = 1;
-                        ni--;
-                    } else {
-                        xc.length = ni + 1;
-                        k = pows10[ LOG_BASE - i ];
-
-                        // E.g. 56700 becomes 56000 if 7 is the rounding digit.
-                        // j > 0 means i > number of leading zeros of n.
-                        xc[ni] = j > 0 ? mathfloor( n / pows10[ d - j ] % pows10[j] ) * k : 0;
-                    }
-
-                    // Round up?
-                    if (r) {
-
-                        for ( ; ; ) {
-
-                            // If the digit to be rounded up is in the first element of xc...
-                            if ( ni == 0 ) {
-
-                                // i will be the length of xc[0] before k is added.
-                                for ( i = 1, j = xc[0]; j >= 10; j /= 10, i++ );
-                                j = xc[0] += k;
-                                for ( k = 1; j >= 10; j /= 10, k++ );
-
-                                // if i != k the length has increased.
-                                if ( i != k ) {
-                                    x.e++;
-                                    if ( xc[0] == BASE ) xc[0] = 1;
-                                }
-
-                                break;
-                            } else {
-                                xc[ni] += k;
-                                if ( xc[ni] != BASE ) break;
-                                xc[ni--] = 0;
-                                k = 1;
-                            }
-                        }
-                    }
-
-                    // Remove trailing zeros.
-                    for ( i = xc.length; xc[--i] === 0; xc.pop() );
-                }
-
-                // Overflow? Infinity.
-                if ( x.e > MAX_EXP ) {
-                    x.c = x.e = null;
-
-                // Underflow? Zero.
-                } else if ( x.e < MIN_EXP ) {
-                    x.c = [ x.e = 0 ];
-                }
-            }
-
-            return x;
-        }
-
-
-        // PROTOTYPE/INSTANCE METHODS
-
-
-        /*
-         * Return a new BigNumber whose value is the absolute value of this BigNumber.
-         */
-        P.absoluteValue = P.abs = function () {
-            var x = new BigNumber(this);
-            if ( x.s < 0 ) x.s = 1;
-            return x;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber rounded to a whole
-         * number in the direction of Infinity.
-         */
-        P.ceil = function () {
-            return round( new BigNumber(this), this.e + 1, 2 );
-        };
-
-
-        /*
-         * Return
-         * 1 if the value of this BigNumber is greater than the value of BigNumber(y, b),
-         * -1 if the value of this BigNumber is less than the value of BigNumber(y, b),
-         * 0 if they have the same value,
-         * or null if the value of either is NaN.
-         */
-        P.comparedTo = P.cmp = function ( y, b ) {
-            id = 1;
-            return compare( this, new BigNumber( y, b ) );
-        };
-
-
-        /*
-         * Return the number of decimal places of the value of this BigNumber, or null if the value
-         * of this BigNumber is ±Infinity or NaN.
-         */
-        P.decimalPlaces = P.dp = function () {
-            var n, v,
-                c = this.c;
-
-            if ( !c ) return null;
-            n = ( ( v = c.length - 1 ) - bitFloor( this.e / LOG_BASE ) ) * LOG_BASE;
-
-            // Subtract the number of trailing zeros of the last number.
-            if ( v = c[v] ) for ( ; v % 10 == 0; v /= 10, n-- );
-            if ( n < 0 ) n = 0;
-
-            return n;
-        };
-
-
-        /*
-         *  n / 0 = I
-         *  n / N = N
-         *  n / I = 0
-         *  0 / n = 0
-         *  0 / 0 = N
-         *  0 / N = N
-         *  0 / I = 0
-         *  N / n = N
-         *  N / 0 = N
-         *  N / N = N
-         *  N / I = N
-         *  I / n = I
-         *  I / 0 = I
-         *  I / N = N
-         *  I / I = N
-         *
-         * Return a new BigNumber whose value is the value of this BigNumber divided by the value of
-         * BigNumber(y, b), rounded according to DECIMAL_PLACES and ROUNDING_MODE.
-         */
-        P.dividedBy = P.div = function ( y, b ) {
-            id = 3;
-            return div( this, new BigNumber( y, b ), DECIMAL_PLACES, ROUNDING_MODE );
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the integer part of dividing the value of this
-         * BigNumber by the value of BigNumber(y, b).
-         */
-        P.dividedToIntegerBy = P.divToInt = function ( y, b ) {
-            id = 4;
-            return div( this, new BigNumber( y, b ), 0, 1 );
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is equal to the value of BigNumber(y, b),
-         * otherwise returns false.
-         */
-        P.equals = P.eq = function ( y, b ) {
-            id = 5;
-            return compare( this, new BigNumber( y, b ) ) === 0;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber rounded to a whole
-         * number in the direction of -Infinity.
-         */
-        P.floor = function () {
-            return round( new BigNumber(this), this.e + 1, 3 );
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is greater than the value of BigNumber(y, b),
-         * otherwise returns false.
-         */
-        P.greaterThan = P.gt = function ( y, b ) {
-            id = 6;
-            return compare( this, new BigNumber( y, b ) ) > 0;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is greater than or equal to the value of
-         * BigNumber(y, b), otherwise returns false.
-         */
-        P.greaterThanOrEqualTo = P.gte = function ( y, b ) {
-            id = 7;
-            return ( b = compare( this, new BigNumber( y, b ) ) ) === 1 || b === 0;
-
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is a finite number, otherwise returns false.
-         */
-        P.isFinite = function () {
-            return !!this.c;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is an integer, otherwise return false.
-         */
-        P.isInteger = P.isInt = function () {
-            return !!this.c && bitFloor( this.e / LOG_BASE ) > this.c.length - 2;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is NaN, otherwise returns false.
-         */
-        P.isNaN = function () {
-            return !this.s;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is negative, otherwise returns false.
-         */
-        P.isNegative = P.isNeg = function () {
-            return this.s < 0;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is 0 or -0, otherwise returns false.
-         */
-        P.isZero = function () {
-            return !!this.c && this.c[0] == 0;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is less than the value of BigNumber(y, b),
-         * otherwise returns false.
-         */
-        P.lessThan = P.lt = function ( y, b ) {
-            id = 8;
-            return compare( this, new BigNumber( y, b ) ) < 0;
-        };
-
-
-        /*
-         * Return true if the value of this BigNumber is less than or equal to the value of
-         * BigNumber(y, b), otherwise returns false.
-         */
-        P.lessThanOrEqualTo = P.lte = function ( y, b ) {
-            id = 9;
-            return ( b = compare( this, new BigNumber( y, b ) ) ) === -1 || b === 0;
-        };
-
-
-        /*
-         *  n - 0 = n
-         *  n - N = N
-         *  n - I = -I
-         *  0 - n = -n
-         *  0 - 0 = 0
-         *  0 - N = N
-         *  0 - I = -I
-         *  N - n = N
-         *  N - 0 = N
-         *  N - N = N
-         *  N - I = N
-         *  I - n = I
-         *  I - 0 = I
-         *  I - N = N
-         *  I - I = N
-         *
-         * Return a new BigNumber whose value is the value of this BigNumber minus the value of
-         * BigNumber(y, b).
-         */
-        P.minus = P.sub = function ( y, b ) {
-            var i, j, t, xLTy,
-                x = this,
-                a = x.s;
-
-            id = 10;
-            y = new BigNumber( y, b );
-            b = y.s;
-
-            // Either NaN?
-            if ( !a || !b ) return new BigNumber(NaN);
-
-            // Signs differ?
-            if ( a != b ) {
-                y.s = -b;
-                return x.plus(y);
-            }
-
-            var xe = x.e / LOG_BASE,
-                ye = y.e / LOG_BASE,
-                xc = x.c,
-                yc = y.c;
-
-            if ( !xe || !ye ) {
-
-                // Either Infinity?
-                if ( !xc || !yc ) return xc ? ( y.s = -b, y ) : new BigNumber( yc ? x : NaN );
-
-                // Either zero?
-                if ( !xc[0] || !yc[0] ) {
-
-                    // Return y if y is non-zero, x if x is non-zero, or zero if both are zero.
-                    return yc[0] ? ( y.s = -b, y ) : new BigNumber( xc[0] ? x :
-
-                      // IEEE 754 (2008) 6.3: n - n = -0 when rounding to -Infinity
-                      ROUNDING_MODE == 3 ? -0 : 0 );
-                }
-            }
-
-            xe = bitFloor(xe);
-            ye = bitFloor(ye);
-            xc = xc.slice();
-
-            // Determine which is the bigger number.
-            if ( a = xe - ye ) {
-
-                if ( xLTy = a < 0 ) {
-                    a = -a;
-                    t = xc;
-                } else {
-                    ye = xe;
-                    t = yc;
-                }
-
-                t.reverse();
-
-                // Prepend zeros to equalise exponents.
-                for ( b = a; b--; t.push(0) );
-                t.reverse();
-            } else {
-
-                // Exponents equal. Check digit by digit.
-                j = ( xLTy = ( a = xc.length ) < ( b = yc.length ) ) ? a : b;
-
-                for ( a = b = 0; b < j; b++ ) {
-
-                    if ( xc[b] != yc[b] ) {
-                        xLTy = xc[b] < yc[b];
-                        break;
-                    }
-                }
-            }
-
-            // x < y? Point xc to the array of the bigger number.
-            if (xLTy) t = xc, xc = yc, yc = t, y.s = -y.s;
-
-            b = ( j = yc.length ) - ( i = xc.length );
-
-            // Append zeros to xc if shorter.
-            // No need to add zeros to yc if shorter as subtract only needs to start at yc.length.
-            if ( b > 0 ) for ( ; b--; xc[i++] = 0 );
-            b = BASE - 1;
-
-            // Subtract yc from xc.
-            for ( ; j > a; ) {
-
-                if ( xc[--j] < yc[j] ) {
-                    for ( i = j; i && !xc[--i]; xc[i] = b );
-                    --xc[i];
-                    xc[j] += BASE;
-                }
-
-                xc[j] -= yc[j];
-            }
-
-            // Remove leading zeros and adjust exponent accordingly.
-            for ( ; xc[0] == 0; xc.splice(0, 1), --ye );
-
-            // Zero?
-            if ( !xc[0] ) {
-
-                // Following IEEE 754 (2008) 6.3,
-                // n - n = +0  but  n - n = -0  when rounding towards -Infinity.
-                y.s = ROUNDING_MODE == 3 ? -1 : 1;
-                y.c = [ y.e = 0 ];
-                return y;
-            }
-
-            // No need to check for Infinity as +x - +y != Infinity && -x - -y != Infinity
-            // for finite x and y.
-            return normalise( y, xc, ye );
-        };
-
-
-        /*
-         *   n % 0 =  N
-         *   n % N =  N
-         *   n % I =  n
-         *   0 % n =  0
-         *  -0 % n = -0
-         *   0 % 0 =  N
-         *   0 % N =  N
-         *   0 % I =  0
-         *   N % n =  N
-         *   N % 0 =  N
-         *   N % N =  N
-         *   N % I =  N
-         *   I % n =  N
-         *   I % 0 =  N
-         *   I % N =  N
-         *   I % I =  N
-         *
-         * Return a new BigNumber whose value is the value of this BigNumber modulo the value of
-         * BigNumber(y, b). The result depends on the value of MODULO_MODE.
-         */
-        P.modulo = P.mod = function ( y, b ) {
-            var q, s,
-                x = this;
-
-            id = 11;
-            y = new BigNumber( y, b );
-
-            // Return NaN if x is Infinity or NaN, or y is NaN or zero.
-            if ( !x.c || !y.s || y.c && !y.c[0] ) {
-                return new BigNumber(NaN);
-
-            // Return x if y is Infinity or x is zero.
-            } else if ( !y.c || x.c && !x.c[0] ) {
-                return new BigNumber(x);
-            }
-
-            if ( MODULO_MODE == 9 ) {
-
-                // Euclidian division: q = sign(y) * floor(x / abs(y))
-                // r = x - qy    where  0 <= r < abs(y)
-                s = y.s;
-                y.s = 1;
-                q = div( x, y, 0, 3 );
-                y.s = s;
-                q.s *= s;
-            } else {
-                q = div( x, y, 0, MODULO_MODE );
-            }
-
-            return x.minus( q.times(y) );
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber negated,
-         * i.e. multiplied by -1.
-         */
-        P.negated = P.neg = function () {
-            var x = new BigNumber(this);
-            x.s = -x.s || null;
-            return x;
-        };
-
-
-        /*
-         *  n + 0 = n
-         *  n + N = N
-         *  n + I = I
-         *  0 + n = n
-         *  0 + 0 = 0
-         *  0 + N = N
-         *  0 + I = I
-         *  N + n = N
-         *  N + 0 = N
-         *  N + N = N
-         *  N + I = N
-         *  I + n = I
-         *  I + 0 = I
-         *  I + N = N
-         *  I + I = I
-         *
-         * Return a new BigNumber whose value is the value of this BigNumber plus the value of
-         * BigNumber(y, b).
-         */
-        P.plus = P.add = function ( y, b ) {
-            var t,
-                x = this,
-                a = x.s;
-
-            id = 12;
-            y = new BigNumber( y, b );
-            b = y.s;
-
-            // Either NaN?
-            if ( !a || !b ) return new BigNumber(NaN);
-
-            // Signs differ?
-             if ( a != b ) {
-                y.s = -b;
-                return x.minus(y);
-            }
-
-            var xe = x.e / LOG_BASE,
-                ye = y.e / LOG_BASE,
-                xc = x.c,
-                yc = y.c;
-
-            if ( !xe || !ye ) {
-
-                // Return ±Infinity if either ±Infinity.
-                if ( !xc || !yc ) return new BigNumber( a / 0 );
-
-                // Either zero?
-                // Return y if y is non-zero, x if x is non-zero, or zero if both are zero.
-                if ( !xc[0] || !yc[0] ) return yc[0] ? y : new BigNumber( xc[0] ? x : a * 0 );
-            }
-
-            xe = bitFloor(xe);
-            ye = bitFloor(ye);
-            xc = xc.slice();
-
-            // Prepend zeros to equalise exponents. Faster to use reverse then do unshifts.
-            if ( a = xe - ye ) {
-                if ( a > 0 ) {
-                    ye = xe;
-                    t = yc;
-                } else {
-                    a = -a;
-                    t = xc;
-                }
-
-                t.reverse();
-                for ( ; a--; t.push(0) );
-                t.reverse();
-            }
-
-            a = xc.length;
-            b = yc.length;
-
-            // Point xc to the longer array, and b to the shorter length.
-            if ( a - b < 0 ) t = yc, yc = xc, xc = t, b = a;
-
-            // Only start adding at yc.length - 1 as the further digits of xc can be ignored.
-            for ( a = 0; b; ) {
-                a = ( xc[--b] = xc[b] + yc[b] + a ) / BASE | 0;
-                xc[b] = BASE === xc[b] ? 0 : xc[b] % BASE;
-            }
-
-            if (a) {
-                xc = [a].concat(xc);
-                ++ye;
-            }
-
-            // No need to check for zero, as +x + +y != 0 && -x + -y != 0
-            // ye = MAX_EXP + 1 possible
-            return normalise( y, xc, ye );
-        };
-
-
-        /*
-         * Return the number of significant digits of the value of this BigNumber.
-         *
-         * [z] {boolean|number} Whether to count integer-part trailing zeros: true, false, 1 or 0.
-         */
-        P.precision = P.sd = function (z) {
-            var n, v,
-                x = this,
-                c = x.c;
-
-            // 'precision() argument not a boolean or binary digit: {z}'
-            if ( z != null && z !== !!z && z !== 1 && z !== 0 ) {
-                if (ERRORS) raise( 13, 'argument' + notBool, z );
-                if ( z != !!z ) z = null;
-            }
-
-            if ( !c ) return null;
-            v = c.length - 1;
-            n = v * LOG_BASE + 1;
-
-            if ( v = c[v] ) {
-
-                // Subtract the number of trailing zeros of the last element.
-                for ( ; v % 10 == 0; v /= 10, n-- );
-
-                // Add the number of digits of the first element.
-                for ( v = c[0]; v >= 10; v /= 10, n++ );
-            }
-
-            if ( z && x.e + 1 > n ) n = x.e + 1;
-
-            return n;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber rounded to a maximum of
-         * dp decimal places using rounding mode rm, or to 0 and ROUNDING_MODE respectively if
-         * omitted.
-         *
-         * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'round() decimal places out of range: {dp}'
-         * 'round() decimal places not an integer: {dp}'
-         * 'round() rounding mode not an integer: {rm}'
-         * 'round() rounding mode out of range: {rm}'
-         */
-        P.round = function ( dp, rm ) {
-            var n = new BigNumber(this);
-
-            if ( dp == null || isValidInt( dp, 0, MAX, 15 ) ) {
-                round( n, ~~dp + this.e + 1, rm == null ||
-                  !isValidInt( rm, 0, 8, 15, roundingMode ) ? ROUNDING_MODE : rm | 0 );
-            }
-
-            return n;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber shifted by k places
-         * (powers of 10). Shift to the right if n > 0, and to the left if n < 0.
-         *
-         * k {number} Integer, -MAX_SAFE_INTEGER to MAX_SAFE_INTEGER inclusive.
-         *
-         * If k is out of range and ERRORS is false, the result will be ±0 if k < 0, or ±Infinity
-         * otherwise.
-         *
-         * 'shift() argument not an integer: {k}'
-         * 'shift() argument out of range: {k}'
-         */
-        P.shift = function (k) {
-            var n = this;
-            return isValidInt( k, -MAX_SAFE_INTEGER, MAX_SAFE_INTEGER, 16, 'argument' )
-
-              // k < 1e+21, or truncate(k) will produce exponential notation.
-              ? n.times( '1e' + truncate(k) )
-              : new BigNumber( n.c && n.c[0] && ( k < -MAX_SAFE_INTEGER || k > MAX_SAFE_INTEGER )
-                ? n.s * ( k < 0 ? 0 : 1 / 0 )
-                : n );
-        };
-
-
-        /*
-         *  sqrt(-n) =  N
-         *  sqrt( N) =  N
-         *  sqrt(-I) =  N
-         *  sqrt( I) =  I
-         *  sqrt( 0) =  0
-         *  sqrt(-0) = -0
-         *
-         * Return a new BigNumber whose value is the square root of the value of this BigNumber,
-         * rounded according to DECIMAL_PLACES and ROUNDING_MODE.
-         */
-        P.squareRoot = P.sqrt = function () {
-            var m, n, r, rep, t,
-                x = this,
-                c = x.c,
-                s = x.s,
-                e = x.e,
-                dp = DECIMAL_PLACES + 4,
-                half = new BigNumber('0.5');
-
-            // Negative/NaN/Infinity/zero?
-            if ( s !== 1 || !c || !c[0] ) {
-                return new BigNumber( !s || s < 0 && ( !c || c[0] ) ? NaN : c ? x : 1 / 0 );
-            }
-
-            // Initial estimate.
-            s = Math.sqrt( +x );
-
-            // Math.sqrt underflow/overflow?
-            // Pass x to Math.sqrt as integer, then adjust the exponent of the result.
-            if ( s == 0 || s == 1 / 0 ) {
-                n = coeffToString(c);
-                if ( ( n.length + e ) % 2 == 0 ) n += '0';
-                s = Math.sqrt(n);
-                e = bitFloor( ( e + 1 ) / 2 ) - ( e < 0 || e % 2 );
-
-                if ( s == 1 / 0 ) {
-                    n = '1e' + e;
-                } else {
-                    n = s.toExponential();
-                    n = n.slice( 0, n.indexOf('e') + 1 ) + e;
-                }
-
-                r = new BigNumber(n);
-            } else {
-                r = new BigNumber( s + '' );
-            }
-
-            // Check for zero.
-            // r could be zero if MIN_EXP is changed after the this value was created.
-            // This would cause a division by zero (x/t) and hence Infinity below, which would cause
-            // coeffToString to throw.
-            if ( r.c[0] ) {
-                e = r.e;
-                s = e + dp;
-                if ( s < 3 ) s = 0;
-
-                // Newton-Raphson iteration.
-                for ( ; ; ) {
-                    t = r;
-                    r = half.times( t.plus( div( x, t, dp, 1 ) ) );
-
-                    if ( coeffToString( t.c   ).slice( 0, s ) === ( n =
-                         coeffToString( r.c ) ).slice( 0, s ) ) {
-
-                        // The exponent of r may here be one less than the final result exponent,
-                        // e.g 0.0009999 (e-4) --> 0.001 (e-3), so adjust s so the rounding digits
-                        // are indexed correctly.
-                        if ( r.e < e ) --s;
-                        n = n.slice( s - 3, s + 1 );
-
-                        // The 4th rounding digit may be in error by -1 so if the 4 rounding digits
-                        // are 9999 or 4999 (i.e. approaching a rounding boundary) continue the
-                        // iteration.
-                        if ( n == '9999' || !rep && n == '4999' ) {
-
-                            // On the first iteration only, check to see if rounding up gives the
-                            // exact result as the nines may infinitely repeat.
-                            if ( !rep ) {
-                                round( t, t.e + DECIMAL_PLACES + 2, 0 );
-
-                                if ( t.times(t).eq(x) ) {
-                                    r = t;
-                                    break;
-                                }
-                            }
-
-                            dp += 4;
-                            s += 4;
-                            rep = 1;
-                        } else {
-
-                            // If rounding digits are null, 0{0,4} or 50{0,3}, check for exact
-                            // result. If not, then there are further digits and m will be truthy.
-                            if ( !+n || !+n.slice(1) && n.charAt(0) == '5' ) {
-
-                                // Truncate to the first rounding digit.
-                                round( r, r.e + DECIMAL_PLACES + 2, 1 );
-                                m = !r.times(r).eq(x);
-                            }
-
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return round( r, r.e + DECIMAL_PLACES + 1, ROUNDING_MODE, m );
-        };
-
-
-        /*
-         *  n * 0 = 0
-         *  n * N = N
-         *  n * I = I
-         *  0 * n = 0
-         *  0 * 0 = 0
-         *  0 * N = N
-         *  0 * I = N
-         *  N * n = N
-         *  N * 0 = N
-         *  N * N = N
-         *  N * I = N
-         *  I * n = I
-         *  I * 0 = N
-         *  I * N = N
-         *  I * I = I
-         *
-         * Return a new BigNumber whose value is the value of this BigNumber times the value of
-         * BigNumber(y, b).
-         */
-        P.times = P.mul = function ( y, b ) {
-            var c, e, i, j, k, m, xcL, xlo, xhi, ycL, ylo, yhi, zc,
-                base, sqrtBase,
-                x = this,
-                xc = x.c,
-                yc = ( id = 17, y = new BigNumber( y, b ) ).c;
-
-            // Either NaN, ±Infinity or ±0?
-            if ( !xc || !yc || !xc[0] || !yc[0] ) {
-
-                // Return NaN if either is NaN, or one is 0 and the other is Infinity.
-                if ( !x.s || !y.s || xc && !xc[0] && !yc || yc && !yc[0] && !xc ) {
-                    y.c = y.e = y.s = null;
-                } else {
-                    y.s *= x.s;
-
-                    // Return ±Infinity if either is ±Infinity.
-                    if ( !xc || !yc ) {
-                        y.c = y.e = null;
-
-                    // Return ±0 if either is ±0.
-                    } else {
-                        y.c = [0];
-                        y.e = 0;
-                    }
-                }
-
-                return y;
-            }
-
-            e = bitFloor( x.e / LOG_BASE ) + bitFloor( y.e / LOG_BASE );
-            y.s *= x.s;
-            xcL = xc.length;
-            ycL = yc.length;
-
-            // Ensure xc points to longer array and xcL to its length.
-            if ( xcL < ycL ) zc = xc, xc = yc, yc = zc, i = xcL, xcL = ycL, ycL = i;
-
-            // Initialise the result array with zeros.
-            for ( i = xcL + ycL, zc = []; i--; zc.push(0) );
-
-            base = BASE;
-            sqrtBase = SQRT_BASE;
-
-            for ( i = ycL; --i >= 0; ) {
-                c = 0;
-                ylo = yc[i] % sqrtBase;
-                yhi = yc[i] / sqrtBase | 0;
-
-                for ( k = xcL, j = i + k; j > i; ) {
-                    xlo = xc[--k] % sqrtBase;
-                    xhi = xc[k] / sqrtBase | 0;
-                    m = yhi * xlo + xhi * ylo;
-                    xlo = ylo * xlo + ( ( m % sqrtBase ) * sqrtBase ) + zc[j] + c;
-                    c = ( xlo / base | 0 ) + ( m / sqrtBase | 0 ) + yhi * xhi;
-                    zc[j--] = xlo % base;
-                }
-
-                zc[j] = c;
-            }
-
-            if (c) {
-                ++e;
-            } else {
-                zc.splice(0, 1);
-            }
-
-            return normalise( y, zc, e );
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber rounded to a maximum of
-         * sd significant digits using rounding mode rm, or ROUNDING_MODE if rm is omitted.
-         *
-         * [sd] {number} Significant digits. Integer, 1 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'toDigits() precision out of range: {sd}'
-         * 'toDigits() precision not an integer: {sd}'
-         * 'toDigits() rounding mode not an integer: {rm}'
-         * 'toDigits() rounding mode out of range: {rm}'
-         */
-        P.toDigits = function ( sd, rm ) {
-            var n = new BigNumber(this);
-            sd = sd == null || !isValidInt( sd, 1, MAX, 18, 'precision' ) ? null : sd | 0;
-            rm = rm == null || !isValidInt( rm, 0, 8, 18, roundingMode ) ? ROUNDING_MODE : rm | 0;
-            return sd ? round( n, sd, rm ) : n;
-        };
-
-
-        /*
-         * Return a string representing the value of this BigNumber in exponential notation and
-         * rounded using ROUNDING_MODE to dp fixed decimal places.
-         *
-         * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'toExponential() decimal places not an integer: {dp}'
-         * 'toExponential() decimal places out of range: {dp}'
-         * 'toExponential() rounding mode not an integer: {rm}'
-         * 'toExponential() rounding mode out of range: {rm}'
-         */
-        P.toExponential = function ( dp, rm ) {
-            return format( this,
-              dp != null && isValidInt( dp, 0, MAX, 19 ) ? ~~dp + 1 : null, rm, 19 );
-        };
-
-
-        /*
-         * Return a string representing the value of this BigNumber in fixed-point notation rounding
-         * to dp fixed decimal places using rounding mode rm, or ROUNDING_MODE if rm is omitted.
-         *
-         * Note: as with JavaScript's number type, (-0).toFixed(0) is '0',
-         * but e.g. (-0.00001).toFixed(0) is '-0'.
-         *
-         * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'toFixed() decimal places not an integer: {dp}'
-         * 'toFixed() decimal places out of range: {dp}'
-         * 'toFixed() rounding mode not an integer: {rm}'
-         * 'toFixed() rounding mode out of range: {rm}'
-         */
-        P.toFixed = function ( dp, rm ) {
-            return format( this, dp != null && isValidInt( dp, 0, MAX, 20 )
-              ? ~~dp + this.e + 1 : null, rm, 20 );
-        };
-
-
-        /*
-         * Return a string representing the value of this BigNumber in fixed-point notation rounded
-         * using rm or ROUNDING_MODE to dp decimal places, and formatted according to the properties
-         * of the FORMAT object (see BigNumber.config).
-         *
-         * FORMAT = {
-         *      decimalSeparator : '.',
-         *      groupSeparator : ',',
-         *      groupSize : 3,
-         *      secondaryGroupSize : 0,
-         *      fractionGroupSeparator : '\xA0',    // non-breaking space
-         *      fractionGroupSize : 0
-         * };
-         *
-         * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'toFormat() decimal places not an integer: {dp}'
-         * 'toFormat() decimal places out of range: {dp}'
-         * 'toFormat() rounding mode not an integer: {rm}'
-         * 'toFormat() rounding mode out of range: {rm}'
-         */
-        P.toFormat = function ( dp, rm ) {
-            var str = format( this, dp != null && isValidInt( dp, 0, MAX, 21 )
-              ? ~~dp + this.e + 1 : null, rm, 21 );
-
-            if ( this.c ) {
-                var i,
-                    arr = str.split('.'),
-                    g1 = +FORMAT.groupSize,
-                    g2 = +FORMAT.secondaryGroupSize,
-                    groupSeparator = FORMAT.groupSeparator,
-                    intPart = arr[0],
-                    fractionPart = arr[1],
-                    isNeg = this.s < 0,
-                    intDigits = isNeg ? intPart.slice(1) : intPart,
-                    len = intDigits.length;
-
-                if (g2) i = g1, g1 = g2, g2 = i, len -= i;
-
-                if ( g1 > 0 && len > 0 ) {
-                    i = len % g1 || g1;
-                    intPart = intDigits.substr( 0, i );
-
-                    for ( ; i < len; i += g1 ) {
-                        intPart += groupSeparator + intDigits.substr( i, g1 );
-                    }
-
-                    if ( g2 > 0 ) intPart += groupSeparator + intDigits.slice(i);
-                    if (isNeg) intPart = '-' + intPart;
-                }
-
-                str = fractionPart
-                  ? intPart + FORMAT.decimalSeparator + ( ( g2 = +FORMAT.fractionGroupSize )
-                    ? fractionPart.replace( new RegExp( '\\d{' + g2 + '}\\B', 'g' ),
-                      '$&' + FORMAT.fractionGroupSeparator )
-                    : fractionPart )
-                  : intPart;
-            }
-
-            return str;
-        };
-
-
-        /*
-         * Return a string array representing the value of this BigNumber as a simple fraction with
-         * an integer numerator and an integer denominator. The denominator will be a positive
-         * non-zero value less than or equal to the specified maximum denominator. If a maximum
-         * denominator is not specified, the denominator will be the lowest value necessary to
-         * represent the number exactly.
-         *
-         * [md] {number|string|BigNumber} Integer >= 1 and < Infinity. The maximum denominator.
-         *
-         * 'toFraction() max denominator not an integer: {md}'
-         * 'toFraction() max denominator out of range: {md}'
-         */
-        P.toFraction = function (md) {
-            var arr, d0, d2, e, exp, n, n0, q, s,
-                k = ERRORS,
-                x = this,
-                xc = x.c,
-                d = new BigNumber(ONE),
-                n1 = d0 = new BigNumber(ONE),
-                d1 = n0 = new BigNumber(ONE);
-
-            if ( md != null ) {
-                ERRORS = false;
-                n = new BigNumber(md);
-                ERRORS = k;
-
-                if ( !( k = n.isInt() ) || n.lt(ONE) ) {
-
-                    if (ERRORS) {
-                        raise( 22,
-                          'max denominator ' + ( k ? 'out of range' : 'not an integer' ), md );
-                    }
-
-                    // ERRORS is false:
-                    // If md is a finite non-integer >= 1, round it to an integer and use it.
-                    md = !k && n.c && round( n, n.e + 1, 1 ).gte(ONE) ? n : null;
-                }
-            }
-
-            if ( !xc ) return x.toString();
-            s = coeffToString(xc);
-
-            // Determine initial denominator.
-            // d is a power of 10 and the minimum max denominator that specifies the value exactly.
-            e = d.e = s.length - x.e - 1;
-            d.c[0] = POWS_TEN[ ( exp = e % LOG_BASE ) < 0 ? LOG_BASE + exp : exp ];
-            md = !md || n.cmp(d) > 0 ? ( e > 0 ? d : n1 ) : n;
-
-            exp = MAX_EXP;
-            MAX_EXP = 1 / 0;
-            n = new BigNumber(s);
-
-            // n0 = d1 = 0
-            n0.c[0] = 0;
-
-            for ( ; ; )  {
-                q = div( n, d, 0, 1 );
-                d2 = d0.plus( q.times(d1) );
-                if ( d2.cmp(md) == 1 ) break;
-                d0 = d1;
-                d1 = d2;
-                n1 = n0.plus( q.times( d2 = n1 ) );
-                n0 = d2;
-                d = n.minus( q.times( d2 = d ) );
-                n = d2;
-            }
-
-            d2 = div( md.minus(d0), d1, 0, 1 );
-            n0 = n0.plus( d2.times(n1) );
-            d0 = d0.plus( d2.times(d1) );
-            n0.s = n1.s = x.s;
-            e *= 2;
-
-            // Determine which fraction is closer to x, n0/d0 or n1/d1
-            arr = div( n1, d1, e, ROUNDING_MODE ).minus(x).abs().cmp(
-                  div( n0, d0, e, ROUNDING_MODE ).minus(x).abs() ) < 1
-                    ? [ n1.toString(), d1.toString() ]
-                    : [ n0.toString(), d0.toString() ];
-
-            MAX_EXP = exp;
-            return arr;
-        };
-
-
-        /*
-         * Return the value of this BigNumber converted to a number primitive.
-         */
-        P.toNumber = function () {
-            return +this;
-        };
-
-
-        /*
-         * Return a BigNumber whose value is the value of this BigNumber raised to the power n.
-         * If m is present, return the result modulo m.
-         * If n is negative round according to DECIMAL_PLACES and ROUNDING_MODE.
-         * If POW_PRECISION is non-zero and m is not present, round to POW_PRECISION using
-         * ROUNDING_MODE.
-         *
-         * The modular power operation works efficiently when x, n, and m are positive integers,
-         * otherwise it is equivalent to calculating x.toPower(n).modulo(m) (with POW_PRECISION 0).
-         *
-         * n {number} Integer, -MAX_SAFE_INTEGER to MAX_SAFE_INTEGER inclusive.
-         * [m] {number|string|BigNumber} The modulus.
-         *
-         * 'pow() exponent not an integer: {n}'
-         * 'pow() exponent out of range: {n}'
-         *
-         * Performs 54 loop iterations for n of 9007199254740991.
-         */
-        P.toPower = P.pow = function ( n, m ) {
-            var k, y, z,
-                i = mathfloor( n < 0 ? -n : +n ),
-                x = this;
-
-            if ( m != null ) {
-                id = 23;
-                m = new BigNumber(m);
-            }
-
-            // Pass ±Infinity to Math.pow if exponent is out of range.
-            if ( !isValidInt( n, -MAX_SAFE_INTEGER, MAX_SAFE_INTEGER, 23, 'exponent' ) &&
-              ( !isFinite(n) || i > MAX_SAFE_INTEGER && ( n /= 0 ) ||
-                parseFloat(n) != n && !( n = NaN ) ) || n == 0 ) {
-                k = Math.pow( +x, n );
-                return new BigNumber( m ? k % m : k );
-            }
-
-            if (m) {
-                if ( n > 1 && x.gt(ONE) && x.isInt() && m.gt(ONE) && m.isInt() ) {
-                    x = x.mod(m);
-                } else {
-                    z = m;
-
-                    // Nullify m so only a single mod operation is performed at the end.
-                    m = null;
-                }
-            } else if (POW_PRECISION) {
-
-                // Truncating each coefficient array to a length of k after each multiplication
-                // equates to truncating significant digits to POW_PRECISION + [28, 41],
-                // i.e. there will be a minimum of 28 guard digits retained.
-                // (Using + 1.5 would give [9, 21] guard digits.)
-                k = mathceil( POW_PRECISION / LOG_BASE + 2 );
-            }
-
-            y = new BigNumber(ONE);
-
-            for ( ; ; ) {
-                if ( i % 2 ) {
-                    y = y.times(x);
-                    if ( !y.c ) break;
-                    if (k) {
-                        if ( y.c.length > k ) y.c.length = k;
-                    } else if (m) {
-                        y = y.mod(m);
-                    }
-                }
-
-                i = mathfloor( i / 2 );
-                if ( !i ) break;
-                x = x.times(x);
-                if (k) {
-                    if ( x.c && x.c.length > k ) x.c.length = k;
-                } else if (m) {
-                    x = x.mod(m);
-                }
-            }
-
-            if (m) return y;
-            if ( n < 0 ) y = ONE.div(y);
-
-            return z ? y.mod(z) : k ? round( y, POW_PRECISION, ROUNDING_MODE ) : y;
-        };
-
-
-        /*
-         * Return a string representing the value of this BigNumber rounded to sd significant digits
-         * using rounding mode rm or ROUNDING_MODE. If sd is less than the number of digits
-         * necessary to represent the integer part of the value in fixed-point notation, then use
-         * exponential notation.
-         *
-         * [sd] {number} Significant digits. Integer, 1 to MAX inclusive.
-         * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
-         *
-         * 'toPrecision() precision not an integer: {sd}'
-         * 'toPrecision() precision out of range: {sd}'
-         * 'toPrecision() rounding mode not an integer: {rm}'
-         * 'toPrecision() rounding mode out of range: {rm}'
-         */
-        P.toPrecision = function ( sd, rm ) {
-            return format( this, sd != null && isValidInt( sd, 1, MAX, 24, 'precision' )
-              ? sd | 0 : null, rm, 24 );
-        };
-
-
-        /*
-         * Return a string representing the value of this BigNumber in base b, or base 10 if b is
-         * omitted. If a base is specified, including base 10, round according to DECIMAL_PLACES and
-         * ROUNDING_MODE. If a base is not specified, and this BigNumber has a positive exponent
-         * that is equal to or greater than TO_EXP_POS, or a negative exponent equal to or less than
-         * TO_EXP_NEG, return exponential notation.
-         *
-         * [b] {number} Integer, 2 to 64 inclusive.
-         *
-         * 'toString() base not an integer: {b}'
-         * 'toString() base out of range: {b}'
-         */
-        P.toString = function (b) {
-            var str,
-                n = this,
-                s = n.s,
-                e = n.e;
-
-            // Infinity or NaN?
-            if ( e === null ) {
-
-                if (s) {
-                    str = 'Infinity';
-                    if ( s < 0 ) str = '-' + str;
-                } else {
-                    str = 'NaN';
-                }
-            } else {
-                str = coeffToString( n.c );
-
-                if ( b == null || !isValidInt( b, 2, 64, 25, 'base' ) ) {
-                    str = e <= TO_EXP_NEG || e >= TO_EXP_POS
-                      ? toExponential( str, e )
-                      : toFixedPoint( str, e );
-                } else {
-                    str = convertBase( toFixedPoint( str, e ), b | 0, 10, s );
-                }
-
-                if ( s < 0 && n.c[0] ) str = '-' + str;
-            }
-
-            return str;
-        };
-
-
-        /*
-         * Return a new BigNumber whose value is the value of this BigNumber truncated to a whole
-         * number.
-         */
-        P.truncated = P.trunc = function () {
-            return round( new BigNumber(this), this.e + 1, 1 );
-        };
-
-
-        /*
-         * Return as toString, but do not accept a base argument, and include the minus sign for
-         * negative zero.
-         */
-        P.valueOf = P.toJSON = function () {
-            var str,
-                n = this,
-                e = n.e;
-
-            if ( e === null ) return n.toString();
-
-            str = coeffToString( n.c );
-
-            str = e <= TO_EXP_NEG || e >= TO_EXP_POS
-                ? toExponential( str, e )
-                : toFixedPoint( str, e );
-
-            return n.s < 0 ? '-' + str : str;
-        };
-
-
-        P.isBigNumber = true;
-
-        if ( config != null ) BigNumber.config(config);
-
-        return BigNumber;
+/***/ (function(__webpack_module__, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "BigNumber", function() { return BigNumber; });
+/*
+ *      bignumber.js v7.2.1
+ *      A JavaScript library for arbitrary-precision arithmetic.
+ *      https://github.com/MikeMcl/bignumber.js
+ *      Copyright (c) 2018 Michael Mclaughlin <M8ch88l@gmail.com>
+ *      MIT Licensed.
+ *
+ *      BigNumber.prototype methods     |  BigNumber methods
+ *                                      |
+ *      absoluteValue            abs    |  clone
+ *      comparedTo                      |  config               set
+ *      decimalPlaces            dp     |      DECIMAL_PLACES
+ *      dividedBy                div    |      ROUNDING_MODE
+ *      dividedToIntegerBy       idiv   |      EXPONENTIAL_AT
+ *      exponentiatedBy          pow    |      RANGE
+ *      integerValue                    |      CRYPTO
+ *      isEqualTo                eq     |      MODULO_MODE
+ *      isFinite                        |      POW_PRECISION
+ *      isGreaterThan            gt     |      FORMAT
+ *      isGreaterThanOrEqualTo   gte    |      ALPHABET
+ *      isInteger                       |  isBigNumber
+ *      isLessThan               lt     |  maximum              max
+ *      isLessThanOrEqualTo      lte    |  minimum              min
+ *      isNaN                           |  random
+ *      isNegative                      |
+ *      isPositive                      |
+ *      isZero                          |
+ *      minus                           |
+ *      modulo                   mod    |
+ *      multipliedBy             times  |
+ *      negated                         |
+ *      plus                            |
+ *      precision                sd     |
+ *      shiftedBy                       |
+ *      squareRoot               sqrt   |
+ *      toExponential                   |
+ *      toFixed                         |
+ *      toFormat                        |
+ *      toFraction                      |
+ *      toJSON                          |
+ *      toNumber                        |
+ *      toPrecision                     |
+ *      toString                        |
+ *      valueOf                         |
+ *
+ */
+
+
+var isNumeric = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i,
+
+  mathceil = Math.ceil,
+  mathfloor = Math.floor,
+
+  bignumberError = '[BigNumber Error] ',
+  tooManyDigits = bignumberError + 'Number primitive has more than 15 significant digits: ',
+
+  BASE = 1e14,
+  LOG_BASE = 14,
+  MAX_SAFE_INTEGER = 0x1fffffffffffff,         // 2^53 - 1
+  // MAX_INT32 = 0x7fffffff,                   // 2^31 - 1
+  POWS_TEN = [1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13],
+  SQRT_BASE = 1e7,
+
+  // EDITABLE
+  // The limit on the value of DECIMAL_PLACES, TO_EXP_NEG, TO_EXP_POS, MIN_EXP, MAX_EXP, and
+  // the arguments to toExponential, toFixed, toFormat, and toPrecision.
+  MAX = 1E9;                                   // 0 to MAX_INT32
+
+
+/*
+ * Create and return a BigNumber constructor.
+ */
+function clone(configObject) {
+  var div, convertBase, parseNumeric,
+    P = BigNumber.prototype = { constructor: BigNumber, toString: null, valueOf: null },
+    ONE = new BigNumber(1),
+
+
+    //----------------------------- EDITABLE CONFIG DEFAULTS -------------------------------
+
+
+    // The default values below must be integers within the inclusive ranges stated.
+    // The values can also be changed at run-time using BigNumber.set.
+
+    // The maximum number of decimal places for operations involving division.
+    DECIMAL_PLACES = 20,                     // 0 to MAX
+
+    // The rounding mode used when rounding to the above decimal places, and when using
+    // toExponential, toFixed, toFormat and toPrecision, and round (default value).
+    // UP         0 Away from zero.
+    // DOWN       1 Towards zero.
+    // CEIL       2 Towards +Infinity.
+    // FLOOR      3 Towards -Infinity.
+    // HALF_UP    4 Towards nearest neighbour. If equidistant, up.
+    // HALF_DOWN  5 Towards nearest neighbour. If equidistant, down.
+    // HALF_EVEN  6 Towards nearest neighbour. If equidistant, towards even neighbour.
+    // HALF_CEIL  7 Towards nearest neighbour. If equidistant, towards +Infinity.
+    // HALF_FLOOR 8 Towards nearest neighbour. If equidistant, towards -Infinity.
+    ROUNDING_MODE = 4,                       // 0 to 8
+
+    // EXPONENTIAL_AT : [TO_EXP_NEG , TO_EXP_POS]
+
+    // The exponent value at and beneath which toString returns exponential notation.
+    // Number type: -7
+    TO_EXP_NEG = -7,                         // 0 to -MAX
+
+    // The exponent value at and above which toString returns exponential notation.
+    // Number type: 21
+    TO_EXP_POS = 21,                         // 0 to MAX
+
+    // RANGE : [MIN_EXP, MAX_EXP]
+
+    // The minimum exponent value, beneath which underflow to zero occurs.
+    // Number type: -324  (5e-324)
+    MIN_EXP = -1e7,                          // -1 to -MAX
+
+    // The maximum exponent value, above which overflow to Infinity occurs.
+    // Number type:  308  (1.7976931348623157e+308)
+    // For MAX_EXP > 1e7, e.g. new BigNumber('1e100000000').plus(1) may be slow.
+    MAX_EXP = 1e7,                           // 1 to MAX
+
+    // Whether to use cryptographically-secure random number generation, if available.
+    CRYPTO = false,                          // true or false
+
+    // The modulo mode used when calculating the modulus: a mod n.
+    // The quotient (q = a / n) is calculated according to the corresponding rounding mode.
+    // The remainder (r) is calculated as: r = a - n * q.
+    //
+    // UP        0 The remainder is positive if the dividend is negative, else is negative.
+    // DOWN      1 The remainder has the same sign as the dividend.
+    //             This modulo mode is commonly known as 'truncated division' and is
+    //             equivalent to (a % n) in JavaScript.
+    // FLOOR     3 The remainder has the same sign as the divisor (Python %).
+    // HALF_EVEN 6 This modulo mode implements the IEEE 754 remainder function.
+    // EUCLID    9 Euclidian division. q = sign(n) * floor(a / abs(n)).
+    //             The remainder is always positive.
+    //
+    // The truncated division, floored division, Euclidian division and IEEE 754 remainder
+    // modes are commonly used for the modulus operation.
+    // Although the other rounding modes can also be used, they may not give useful results.
+    MODULO_MODE = 1,                         // 0 to 9
+
+    // The maximum number of significant digits of the result of the exponentiatedBy operation.
+    // If POW_PRECISION is 0, there will be unlimited significant digits.
+    POW_PRECISION = 0,                    // 0 to MAX
+
+    // The format specification used by the BigNumber.prototype.toFormat method.
+    FORMAT = {
+      decimalSeparator: '.',
+      groupSeparator: ',',
+      groupSize: 3,
+      secondaryGroupSize: 0,
+      fractionGroupSeparator: '\xA0',      // non-breaking space
+      fractionGroupSize: 0
+    },
+
+    // The alphabet used for base conversion.
+    // It must be at least 2 characters long, with no '.' or repeated character.
+    // '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_'
+    ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+
+  //------------------------------------------------------------------------------------------
+
+
+  // CONSTRUCTOR
+
+
+  /*
+   * The BigNumber constructor and exported function.
+   * Create and return a new instance of a BigNumber object.
+   *
+   * n {number|string|BigNumber} A numeric value.
+   * [b] {number} The base of n. Integer, 2 to ALPHABET.length inclusive.
+   */
+  function BigNumber(n, b) {
+    var alphabet, c, caseChanged, e, i, isNum, len, str,
+      x = this;
+
+    // Enable constructor usage without new.
+    if (!(x instanceof BigNumber)) {
+
+      // Don't throw on constructor call without new (#81).
+      // '[BigNumber Error] Constructor call without new: {n}'
+      //throw Error(bignumberError + ' Constructor call without new: ' + n);
+      return new BigNumber(n, b);
     }
 
+    if (b == null) {
 
-    // PRIVATE HELPER FUNCTIONS
+      // Duplicate.
+      if (n instanceof BigNumber) {
+        x.s = n.s;
+        x.e = n.e;
+        x.c = (n = n.c) ? n.slice() : n;
+        return;
+      }
 
+      isNum = typeof n == 'number';
 
-    function bitFloor(n) {
-        var i = n | 0;
-        return n > 0 || n === i ? i : i - 1;
-    }
+      if (isNum && n * 0 == 0) {
 
+        // Use `1 / n` to handle minus zero also.
+        x.s = 1 / n < 0 ? (n = -n, -1) : 1;
 
-    // Return a coefficient array as a string of base 10 digits.
-    function coeffToString(a) {
-        var s, z,
-            i = 1,
-            j = a.length,
-            r = a[0] + '';
-
-        for ( ; i < j; ) {
-            s = a[i++] + '';
-            z = LOG_BASE - s.length;
-            for ( ; z--; s = '0' + s );
-            r += s;
+        // Faster path for integers.
+        if (n === ~~n) {
+          for (e = 0, i = n; i >= 10; i /= 10, e++);
+          x.e = e;
+          x.c = [n];
+          return;
         }
 
-        // Determine trailing zeros.
-        for ( j = r.length; r.charCodeAt(--j) === 48; );
-        return r.slice( 0, j + 1 || 1 );
+        str = n + '';
+      } else {
+        if (!isNumeric.test(str = n + '')) return parseNumeric(x, str, isNum);
+        x.s = str.charCodeAt(0) == 45 ? (str = str.slice(1), -1) : 1;
+      }
+
+      // Decimal point?
+        if ((e = str.indexOf('.')) > -1) str = str.replace('.', '');
+
+        // Exponential form?
+        if ((i = str.search(/e/i)) > 0) {
+
+          // Determine exponent.
+          if (e < 0) e = i;
+          e += +str.slice(i + 1);
+          str = str.substring(0, i);
+        } else if (e < 0) {
+
+          // Integer.
+          e = str.length;
+        }
+
+    } else {
+
+      // '[BigNumber Error] Base {not a primitive number|not an integer|out of range}: {b}'
+      intCheck(b, 2, ALPHABET.length, 'Base');
+      str = n + '';
+
+      // Allow exponential notation to be used with base 10 argument, while
+      // also rounding to DECIMAL_PLACES as with other bases.
+      if (b == 10) {
+        x = new BigNumber(n instanceof BigNumber ? n : str);
+        return round(x, DECIMAL_PLACES + x.e + 1, ROUNDING_MODE);
+      }
+
+      isNum = typeof n == 'number';
+
+      if (isNum) {
+
+        // Avoid potential interpretation of Infinity and NaN as base 44+ values.
+        if (n * 0 != 0) return parseNumeric(x, str, isNum, b);
+
+        x.s = 1 / n < 0 ? (str = str.slice(1), -1) : 1;
+
+        // '[BigNumber Error] Number primitive has more than 15 significant digits: {n}'
+        if (BigNumber.DEBUG && str.replace(/^0\.0*|\./, '').length > 15) {
+          throw Error
+           (tooManyDigits + n);
+        }
+
+        // Prevent later check for length on converted number.
+        isNum = false;
+      } else {
+        x.s = str.charCodeAt(0) === 45 ? (str = str.slice(1), -1) : 1;
+      }
+
+      alphabet = ALPHABET.slice(0, b);
+      e = i = 0;
+
+      // Check that str is a valid base b number.
+      // Don't use RegExp so alphabet can contain special characters.
+      for (len = str.length; i < len; i++) {
+        if (alphabet.indexOf(c = str.charAt(i)) < 0) {
+          if (c == '.') {
+
+            // If '.' is not the first character and it has not be found before.
+            if (i > e) {
+              e = len;
+              continue;
+            }
+          } else if (!caseChanged) {
+
+            // Allow e.g. hexadecimal 'FF' as well as 'ff'.
+            if (str == str.toUpperCase() && (str = str.toLowerCase()) ||
+                str == str.toLowerCase() && (str = str.toUpperCase())) {
+              caseChanged = true;
+              i = -1;
+              e = 0;
+              continue;
+            }
+          }
+
+          return parseNumeric(x, n + '', isNum, b);
+        }
+      }
+
+      str = convertBase(str, b, 10, x.s);
+
+      // Decimal point?
+      if ((e = str.indexOf('.')) > -1) str = str.replace('.', '');
+      else e = str.length;
     }
 
+    // Determine leading zeros.
+    for (i = 0; str.charCodeAt(i) === 48; i++);
 
-    // Compare the value of BigNumbers x and y.
-    function compare( x, y ) {
-        var a, b,
-            xc = x.c,
-            yc = y.c,
-            i = x.s,
-            j = y.s,
-            k = x.e,
-            l = y.e;
+    // Determine trailing zeros.
+    for (len = str.length; str.charCodeAt(--len) === 48;);
 
-        // Either NaN?
-        if ( !i || !j ) return null;
+    str = str.slice(i, ++len);
 
-        a = xc && !xc[0];
-        b = yc && !yc[0];
+    if (str) {
+      len -= i;
 
-        // Either zero?
-        if ( a || b ) return a ? b ? 0 : -j : i;
+      // '[BigNumber Error] Number primitive has more than 15 significant digits: {n}'
+      if (isNum && BigNumber.DEBUG &&
+        len > 15 && (n > MAX_SAFE_INTEGER || n !== mathfloor(n))) {
+          throw Error
+           (tooManyDigits + (x.s * n));
+      }
 
-        // Signs differ?
-        if ( i != j ) return i;
+      e = e - i - 1;
 
-        a = i < 0;
-        b = k == l;
+       // Overflow?
+      if (e > MAX_EXP) {
 
-        // Either Infinity?
-        if ( !xc || !yc ) return b ? 0 : !xc ^ a ? 1 : -1;
+        // Infinity.
+        x.c = x.e = null;
 
-        // Compare exponents.
-        if ( !b ) return k > l ^ a ? 1 : -1;
+      // Underflow?
+      } else if (e < MIN_EXP) {
 
-        j = ( k = xc.length ) < ( l = yc.length ) ? k : l;
+        // Zero.
+        x.c = [x.e = 0];
+      } else {
+        x.e = e;
+        x.c = [];
 
-        // Compare digit by digit.
-        for ( i = 0; i < j; i++ ) if ( xc[i] != yc[i] ) return xc[i] > yc[i] ^ a ? 1 : -1;
+        // Transform base
 
-        // Compare lengths.
-        return k == l ? 0 : k > l ^ a ? 1 : -1;
+        // e is the base 10 exponent.
+        // i is where to slice str to get the first element of the coefficient array.
+        i = (e + 1) % LOG_BASE;
+        if (e < 0) i += LOG_BASE;
+
+        if (i < len) {
+          if (i) x.c.push(+str.slice(0, i));
+
+          for (len -= LOG_BASE; i < len;) {
+            x.c.push(+str.slice(i, i += LOG_BASE));
+          }
+
+          str = str.slice(i);
+          i = LOG_BASE - str.length;
+        } else {
+          i -= len;
+        }
+
+        for (; i--; str += '0');
+        x.c.push(+str);
+      }
+    } else {
+
+      // Zero.
+      x.c = [x.e = 0];
+    }
+  }
+
+
+  // CONSTRUCTOR PROPERTIES
+
+
+  BigNumber.clone = clone;
+
+  BigNumber.ROUND_UP = 0;
+  BigNumber.ROUND_DOWN = 1;
+  BigNumber.ROUND_CEIL = 2;
+  BigNumber.ROUND_FLOOR = 3;
+  BigNumber.ROUND_HALF_UP = 4;
+  BigNumber.ROUND_HALF_DOWN = 5;
+  BigNumber.ROUND_HALF_EVEN = 6;
+  BigNumber.ROUND_HALF_CEIL = 7;
+  BigNumber.ROUND_HALF_FLOOR = 8;
+  BigNumber.EUCLID = 9;
+
+
+  /*
+   * Configure infrequently-changing library-wide settings.
+   *
+   * Accept an object with the following optional properties (if the value of a property is
+   * a number, it must be an integer within the inclusive range stated):
+   *
+   *   DECIMAL_PLACES   {number}           0 to MAX
+   *   ROUNDING_MODE    {number}           0 to 8
+   *   EXPONENTIAL_AT   {number|number[]}  -MAX to MAX  or  [-MAX to 0, 0 to MAX]
+   *   RANGE            {number|number[]}  -MAX to MAX (not zero)  or  [-MAX to -1, 1 to MAX]
+   *   CRYPTO           {boolean}          true or false
+   *   MODULO_MODE      {number}           0 to 9
+   *   POW_PRECISION       {number}           0 to MAX
+   *   ALPHABET         {string}           A string of two or more unique characters which does
+   *                                     not contain '.'.
+   *   FORMAT           {object}           An object with some of the following properties:
+   *      decimalSeparator       {string}
+   *      groupSeparator         {string}
+   *      groupSize              {number}
+   *      secondaryGroupSize     {number}
+   *      fractionGroupSeparator {string}
+   *      fractionGroupSize      {number}
+   *
+   * (The values assigned to the above FORMAT object properties are not checked for validity.)
+   *
+   * E.g.
+   * BigNumber.config({ DECIMAL_PLACES : 20, ROUNDING_MODE : 4 })
+   *
+   * Ignore properties/parameters set to null or undefined, except for ALPHABET.
+   *
+   * Return an object with the properties current values.
+   */
+  BigNumber.config = BigNumber.set = function (obj) {
+    var p, v;
+
+    if (obj != null) {
+
+      if (typeof obj == 'object') {
+
+        // DECIMAL_PLACES {number} Integer, 0 to MAX inclusive.
+        // '[BigNumber Error] DECIMAL_PLACES {not a primitive number|not an integer|out of range}: {v}'
+        if (obj.hasOwnProperty(p = 'DECIMAL_PLACES')) {
+          v = obj[p];
+          intCheck(v, 0, MAX, p);
+          DECIMAL_PLACES = v;
+        }
+
+        // ROUNDING_MODE {number} Integer, 0 to 8 inclusive.
+        // '[BigNumber Error] ROUNDING_MODE {not a primitive number|not an integer|out of range}: {v}'
+        if (obj.hasOwnProperty(p = 'ROUNDING_MODE')) {
+          v = obj[p];
+          intCheck(v, 0, 8, p);
+          ROUNDING_MODE = v;
+        }
+
+        // EXPONENTIAL_AT {number|number[]}
+        // Integer, -MAX to MAX inclusive or
+        // [integer -MAX to 0 inclusive, 0 to MAX inclusive].
+        // '[BigNumber Error] EXPONENTIAL_AT {not a primitive number|not an integer|out of range}: {v}'
+        if (obj.hasOwnProperty(p = 'EXPONENTIAL_AT')) {
+          v = obj[p];
+          if (isArray(v)) {
+            intCheck(v[0], -MAX, 0, p);
+            intCheck(v[1], 0, MAX, p);
+            TO_EXP_NEG = v[0];
+            TO_EXP_POS = v[1];
+          } else {
+            intCheck(v, -MAX, MAX, p);
+            TO_EXP_NEG = -(TO_EXP_POS = v < 0 ? -v : v);
+          }
+        }
+
+        // RANGE {number|number[]} Non-zero integer, -MAX to MAX inclusive or
+        // [integer -MAX to -1 inclusive, integer 1 to MAX inclusive].
+        // '[BigNumber Error] RANGE {not a primitive number|not an integer|out of range|cannot be zero}: {v}'
+        if (obj.hasOwnProperty(p = 'RANGE')) {
+          v = obj[p];
+          if (isArray(v)) {
+            intCheck(v[0], -MAX, -1, p);
+            intCheck(v[1], 1, MAX, p);
+            MIN_EXP = v[0];
+            MAX_EXP = v[1];
+          } else {
+            intCheck(v, -MAX, MAX, p);
+            if (v) {
+              MIN_EXP = -(MAX_EXP = v < 0 ? -v : v);
+            } else {
+              throw Error
+               (bignumberError + p + ' cannot be zero: ' + v);
+            }
+          }
+        }
+
+        // CRYPTO {boolean} true or false.
+        // '[BigNumber Error] CRYPTO not true or false: {v}'
+        // '[BigNumber Error] crypto unavailable'
+        if (obj.hasOwnProperty(p = 'CRYPTO')) {
+          v = obj[p];
+          if (v === !!v) {
+            if (v) {
+              if (typeof crypto != 'undefined' && crypto &&
+               (crypto.getRandomValues || crypto.randomBytes)) {
+                CRYPTO = v;
+              } else {
+                CRYPTO = !v;
+                throw Error
+                 (bignumberError + 'crypto unavailable');
+              }
+            } else {
+              CRYPTO = v;
+            }
+          } else {
+            throw Error
+             (bignumberError + p + ' not true or false: ' + v);
+          }
+        }
+
+        // MODULO_MODE {number} Integer, 0 to 9 inclusive.
+        // '[BigNumber Error] MODULO_MODE {not a primitive number|not an integer|out of range}: {v}'
+        if (obj.hasOwnProperty(p = 'MODULO_MODE')) {
+          v = obj[p];
+          intCheck(v, 0, 9, p);
+          MODULO_MODE = v;
+        }
+
+        // POW_PRECISION {number} Integer, 0 to MAX inclusive.
+        // '[BigNumber Error] POW_PRECISION {not a primitive number|not an integer|out of range}: {v}'
+        if (obj.hasOwnProperty(p = 'POW_PRECISION')) {
+          v = obj[p];
+          intCheck(v, 0, MAX, p);
+          POW_PRECISION = v;
+        }
+
+        // FORMAT {object}
+        // '[BigNumber Error] FORMAT not an object: {v}'
+        if (obj.hasOwnProperty(p = 'FORMAT')) {
+          v = obj[p];
+          if (typeof v == 'object') FORMAT = v;
+          else throw Error
+           (bignumberError + p + ' not an object: ' + v);
+        }
+
+        // ALPHABET {string}
+        // '[BigNumber Error] ALPHABET invalid: {v}'
+        if (obj.hasOwnProperty(p = 'ALPHABET')) {
+          v = obj[p];
+
+          // Disallow if only one character, or contains '.' or a repeated character.
+          if (typeof v == 'string' && !/^.$|\.|(.).*\1/.test(v)) {
+            ALPHABET = v;
+          } else {
+            throw Error
+             (bignumberError + p + ' invalid: ' + v);
+          }
+        }
+
+      } else {
+
+        // '[BigNumber Error] Object expected: {v}'
+        throw Error
+         (bignumberError + 'Object expected: ' + obj);
+      }
     }
 
+    return {
+      DECIMAL_PLACES: DECIMAL_PLACES,
+      ROUNDING_MODE: ROUNDING_MODE,
+      EXPONENTIAL_AT: [TO_EXP_NEG, TO_EXP_POS],
+      RANGE: [MIN_EXP, MAX_EXP],
+      CRYPTO: CRYPTO,
+      MODULO_MODE: MODULO_MODE,
+      POW_PRECISION: POW_PRECISION,
+      FORMAT: FORMAT,
+      ALPHABET: ALPHABET
+    };
+  };
 
-    /*
-     * Return true if n is a valid number in range, otherwise false.
-     * Use for argument validation when ERRORS is false.
-     * Note: parseInt('1e+1') == 1 but parseFloat('1e+1') == 10.
-     */
-    function intValidatorNoErrors( n, min, max ) {
-        return ( n = truncate(n) ) >= min && n <= max;
-    }
+
+  /*
+   * Return true if v is a BigNumber instance, otherwise return false.
+   *
+   * v {any}
+   */
+  BigNumber.isBigNumber = function (v) {
+    return v instanceof BigNumber || v && v._isBigNumber === true || false;
+  };
 
 
-    function isArray(obj) {
-        return Object.prototype.toString.call(obj) == '[object Array]';
-    }
+  /*
+   * Return a new BigNumber whose value is the maximum of the arguments.
+   *
+   * arguments {number|string|BigNumber}
+   */
+  BigNumber.maximum = BigNumber.max = function () {
+    return maxOrMin(arguments, P.lt);
+  };
 
+
+  /*
+   * Return a new BigNumber whose value is the minimum of the arguments.
+   *
+   * arguments {number|string|BigNumber}
+   */
+  BigNumber.minimum = BigNumber.min = function () {
+    return maxOrMin(arguments, P.gt);
+  };
+
+
+  /*
+   * Return a new BigNumber with a random value equal to or greater than 0 and less than 1,
+   * and with dp, or DECIMAL_PLACES if dp is omitted, decimal places (or less if trailing
+   * zeros are produced).
+   *
+   * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {dp}'
+   * '[BigNumber Error] crypto unavailable'
+   */
+  BigNumber.random = (function () {
+    var pow2_53 = 0x20000000000000;
+
+    // Return a 53 bit integer n, where 0 <= n < 9007199254740992.
+    // Check if Math.random() produces more than 32 bits of randomness.
+    // If it does, assume at least 53 bits are produced, otherwise assume at least 30 bits.
+    // 0x40000000 is 2^30, 0x800000 is 2^23, 0x1fffff is 2^21 - 1.
+    var random53bitInt = (Math.random() * pow2_53) & 0x1fffff
+     ? function () { return mathfloor(Math.random() * pow2_53); }
+     : function () { return ((Math.random() * 0x40000000 | 0) * 0x800000) +
+       (Math.random() * 0x800000 | 0); };
+
+    return function (dp) {
+      var a, b, e, k, v,
+        i = 0,
+        c = [],
+        rand = new BigNumber(ONE);
+
+      if (dp == null) dp = DECIMAL_PLACES;
+      else intCheck(dp, 0, MAX);
+
+      k = mathceil(dp / LOG_BASE);
+
+      if (CRYPTO) {
+
+        // Browsers supporting crypto.getRandomValues.
+        if (crypto.getRandomValues) {
+
+          a = crypto.getRandomValues(new Uint32Array(k *= 2));
+
+          for (; i < k;) {
+
+            // 53 bits:
+            // ((Math.pow(2, 32) - 1) * Math.pow(2, 21)).toString(2)
+            // 11111 11111111 11111111 11111111 11100000 00000000 00000000
+            // ((Math.pow(2, 32) - 1) >>> 11).toString(2)
+            //                                     11111 11111111 11111111
+            // 0x20000 is 2^21.
+            v = a[i] * 0x20000 + (a[i + 1] >>> 11);
+
+            // Rejection sampling:
+            // 0 <= v < 9007199254740992
+            // Probability that v >= 9e15, is
+            // 7199254740992 / 9007199254740992 ~= 0.0008, i.e. 1 in 1251
+            if (v >= 9e15) {
+              b = crypto.getRandomValues(new Uint32Array(2));
+              a[i] = b[0];
+              a[i + 1] = b[1];
+            } else {
+
+              // 0 <= v <= 8999999999999999
+              // 0 <= (v % 1e14) <= 99999999999999
+              c.push(v % 1e14);
+              i += 2;
+            }
+          }
+          i = k / 2;
+
+        // Node.js supporting crypto.randomBytes.
+        } else if (crypto.randomBytes) {
+
+          // buffer
+          a = crypto.randomBytes(k *= 7);
+
+          for (; i < k;) {
+
+            // 0x1000000000000 is 2^48, 0x10000000000 is 2^40
+            // 0x100000000 is 2^32, 0x1000000 is 2^24
+            // 11111 11111111 11111111 11111111 11111111 11111111 11111111
+            // 0 <= v < 9007199254740992
+            v = ((a[i] & 31) * 0x1000000000000) + (a[i + 1] * 0x10000000000) +
+               (a[i + 2] * 0x100000000) + (a[i + 3] * 0x1000000) +
+               (a[i + 4] << 16) + (a[i + 5] << 8) + a[i + 6];
+
+            if (v >= 9e15) {
+              crypto.randomBytes(7).copy(a, i);
+            } else {
+
+              // 0 <= (v % 1e14) <= 99999999999999
+              c.push(v % 1e14);
+              i += 7;
+            }
+          }
+          i = k / 7;
+        } else {
+          CRYPTO = false;
+          throw Error
+           (bignumberError + 'crypto unavailable');
+        }
+      }
+
+      // Use Math.random.
+      if (!CRYPTO) {
+
+        for (; i < k;) {
+          v = random53bitInt();
+          if (v < 9e15) c[i++] = v % 1e14;
+        }
+      }
+
+      k = c[--i];
+      dp %= LOG_BASE;
+
+      // Convert trailing digits to zeros according to dp.
+      if (k && dp) {
+        v = POWS_TEN[LOG_BASE - dp];
+        c[i] = mathfloor(k / v) * v;
+      }
+
+      // Remove trailing elements which are zero.
+      for (; c[i] === 0; c.pop(), i--);
+
+      // Zero?
+      if (i < 0) {
+        c = [e = 0];
+      } else {
+
+        // Remove leading elements which are zero and adjust exponent accordingly.
+        for (e = -1 ; c[0] === 0; c.splice(0, 1), e -= LOG_BASE);
+
+        // Count the digits of the first element of c to determine leading zeros, and...
+        for (i = 1, v = c[0]; v >= 10; v /= 10, i++);
+
+        // adjust the exponent accordingly.
+        if (i < LOG_BASE) e -= LOG_BASE - i;
+      }
+
+      rand.e = e;
+      rand.c = c;
+      return rand;
+    };
+  })();
+
+
+  // PRIVATE FUNCTIONS
+
+
+  // Called by BigNumber and BigNumber.prototype.toString.
+  convertBase = (function () {
+    var decimal = '0123456789';
 
     /*
      * Convert string of baseIn to an array of numbers of baseOut.
-     * Eg. convertBase('255', 10, 16) returns [15, 15].
-     * Eg. convertBase('ff', 16, 10) returns [2, 5, 5].
+     * Eg. toBaseOut('255', 10, 16) returns [15, 15].
+     * Eg. toBaseOut('ff', 16, 10) returns [2, 5, 5].
      */
-    function toBaseOut( str, baseIn, baseOut ) {
-        var j,
-            arr = [0],
-            arrL,
-            i = 0,
-            len = str.length;
+    function toBaseOut(str, baseIn, baseOut, alphabet) {
+      var j,
+        arr = [0],
+        arrL,
+        i = 0,
+        len = str.length;
 
-        for ( ; i < len; ) {
-            for ( arrL = arr.length; arrL--; arr[arrL] *= baseIn );
-            arr[ j = 0 ] += ALPHABET.indexOf( str.charAt( i++ ) );
+      for (; i < len;) {
+        for (arrL = arr.length; arrL--; arr[arrL] *= baseIn);
 
-            for ( ; j < arr.length; j++ ) {
+        arr[0] += alphabet.indexOf(str.charAt(i++));
 
-                if ( arr[j] > baseOut - 1 ) {
-                    if ( arr[j + 1] == null ) arr[j + 1] = 0;
-                    arr[j + 1] += arr[j] / baseOut | 0;
-                    arr[j] %= baseOut;
-                }
+        for (j = 0; j < arr.length; j++) {
+
+          if (arr[j] > baseOut - 1) {
+            if (arr[j + 1] == null) arr[j + 1] = 0;
+            arr[j + 1] += arr[j] / baseOut | 0;
+            arr[j] %= baseOut;
+          }
+        }
+      }
+
+      return arr.reverse();
+    }
+
+    // Convert a numeric string of baseIn to a numeric string of baseOut.
+    // If the caller is toString, we are converting from base 10 to baseOut.
+    // If the caller is BigNumber, we are converting from baseIn to base 10.
+    return function (str, baseIn, baseOut, sign, callerIsToString) {
+      var alphabet, d, e, k, r, x, xc, y,
+        i = str.indexOf('.'),
+        dp = DECIMAL_PLACES,
+        rm = ROUNDING_MODE;
+
+      // Non-integer.
+      if (i >= 0) {
+        k = POW_PRECISION;
+
+        // Unlimited precision.
+        POW_PRECISION = 0;
+        str = str.replace('.', '');
+        y = new BigNumber(baseIn);
+        x = y.pow(str.length - i);
+        POW_PRECISION = k;
+
+        // Convert str as if an integer, then restore the fraction part by dividing the
+        // result by its base raised to a power.
+
+        y.c = toBaseOut(toFixedPoint(coeffToString(x.c), x.e, '0'),
+         10, baseOut, decimal);
+        y.e = y.c.length;
+      }
+
+      // Convert the number as integer.
+
+      xc = toBaseOut(str, baseIn, baseOut, callerIsToString
+       ? (alphabet = ALPHABET, decimal)
+       : (alphabet = decimal, ALPHABET));
+
+      // xc now represents str as an integer and converted to baseOut. e is the exponent.
+      e = k = xc.length;
+
+      // Remove trailing zeros.
+      for (; xc[--k] == 0; xc.pop());
+
+      // Zero?
+      if (!xc[0]) return alphabet.charAt(0);
+
+      // Does str represent an integer? If so, no need for the division.
+      if (i < 0) {
+        --e;
+      } else {
+        x.c = xc;
+        x.e = e;
+
+        // The sign is needed for correct rounding.
+        x.s = sign;
+        x = div(x, y, dp, rm, baseOut);
+        xc = x.c;
+        r = x.r;
+        e = x.e;
+      }
+
+      // xc now represents str converted to baseOut.
+
+      // THe index of the rounding digit.
+      d = e + dp + 1;
+
+      // The rounding digit: the digit to the right of the digit that may be rounded up.
+      i = xc[d];
+
+      // Look at the rounding digits and mode to determine whether to round up.
+
+      k = baseOut / 2;
+      r = r || d < 0 || xc[d + 1] != null;
+
+      r = rm < 4 ? (i != null || r) && (rm == 0 || rm == (x.s < 0 ? 3 : 2))
+            : i > k || i == k &&(rm == 4 || r || rm == 6 && xc[d - 1] & 1 ||
+             rm == (x.s < 0 ? 8 : 7));
+
+      // If the index of the rounding digit is not greater than zero, or xc represents
+      // zero, then the result of the base conversion is zero or, if rounding up, a value
+      // such as 0.00001.
+      if (d < 1 || !xc[0]) {
+
+        // 1^-dp or 0
+        str = r ? toFixedPoint(alphabet.charAt(1), -dp, alphabet.charAt(0))
+            : alphabet.charAt(0);
+      } else {
+
+        // Truncate xc to the required number of decimal places.
+        xc.length = d;
+
+        // Round up?
+        if (r) {
+
+          // Rounding up may mean the previous digit has to be rounded up and so on.
+          for (--baseOut; ++xc[--d] > baseOut;) {
+            xc[d] = 0;
+
+            if (!d) {
+              ++e;
+              xc = [1].concat(xc);
             }
+          }
         }
 
-        return arr.reverse();
+        // Determine trailing zeros.
+        for (k = xc.length; !xc[--k];);
+
+        // E.g. [4, 11, 15] becomes 4bf.
+        for (i = 0, str = ''; i <= k; str += alphabet.charAt(xc[i++]));
+
+        // Add leading zeros, decimal point and trailing zeros as required.
+        str = toFixedPoint(str, e, alphabet.charAt(0));
+      }
+
+      // The caller will add the sign.
+      return str;
+    };
+  })();
+
+
+  // Perform division in the specified base. Called by div and convertBase.
+  div = (function () {
+
+    // Assume non-zero x and k.
+    function multiply(x, k, base) {
+      var m, temp, xlo, xhi,
+        carry = 0,
+        i = x.length,
+        klo = k % SQRT_BASE,
+        khi = k / SQRT_BASE | 0;
+
+      for (x = x.slice(); i--;) {
+        xlo = x[i] % SQRT_BASE;
+        xhi = x[i] / SQRT_BASE | 0;
+        m = khi * xlo + xhi * klo;
+        temp = klo * xlo + ((m % SQRT_BASE) * SQRT_BASE) + carry;
+        carry = (temp / base | 0) + (m / SQRT_BASE | 0) + khi * xhi;
+        x[i] = temp % base;
+      }
+
+      if (carry) x = [carry].concat(x);
+
+      return x;
     }
 
+    function compare(a, b, aL, bL) {
+      var i, cmp;
 
-    function toExponential( str, e ) {
-        return ( str.length > 1 ? str.charAt(0) + '.' + str.slice(1) : str ) +
-          ( e < 0 ? 'e' : 'e+' ) + e;
+      if (aL != bL) {
+        cmp = aL > bL ? 1 : -1;
+      } else {
+
+        for (i = cmp = 0; i < aL; i++) {
+
+          if (a[i] != b[i]) {
+            cmp = a[i] > b[i] ? 1 : -1;
+            break;
+          }
+        }
+      }
+
+      return cmp;
     }
 
+    function subtract(a, b, aL, base) {
+      var i = 0;
 
-    function toFixedPoint( str, e ) {
-        var len, z;
+      // Subtract b from a.
+      for (; aL--;) {
+        a[aL] -= i;
+        i = a[aL] < b[aL] ? 1 : 0;
+        a[aL] = i * base + a[aL] - b[aL];
+      }
 
-        // Negative exponent?
-        if ( e < 0 ) {
+      // Remove leading zeros.
+      for (; !a[0] && a.length > 1; a.splice(0, 1));
+    }
 
-            // Prepend zeros.
-            for ( z = '0.'; ++e; z += '0' );
-            str = z + str;
+    // x: dividend, y: divisor.
+    return function (x, y, dp, rm, base) {
+      var cmp, e, i, more, n, prod, prodL, q, qc, rem, remL, rem0, xi, xL, yc0,
+        yL, yz,
+        s = x.s == y.s ? 1 : -1,
+        xc = x.c,
+        yc = y.c;
 
-        // Positive exponent
+      // Either NaN, Infinity or 0?
+      if (!xc || !xc[0] || !yc || !yc[0]) {
+
+        return new BigNumber(
+
+         // Return NaN if either NaN, or both Infinity or 0.
+         !x.s || !y.s || (xc ? yc && xc[0] == yc[0] : !yc) ? NaN :
+
+          // Return ±0 if x is ±0 or y is ±Infinity, or return ±Infinity as y is ±0.
+          xc && xc[0] == 0 || !yc ? s * 0 : s / 0
+       );
+      }
+
+      q = new BigNumber(s);
+      qc = q.c = [];
+      e = x.e - y.e;
+      s = dp + e + 1;
+
+      if (!base) {
+        base = BASE;
+        e = bitFloor(x.e / LOG_BASE) - bitFloor(y.e / LOG_BASE);
+        s = s / LOG_BASE | 0;
+      }
+
+      // Result exponent may be one less then the current value of e.
+      // The coefficients of the BigNumbers from convertBase may have trailing zeros.
+      for (i = 0; yc[i] == (xc[i] || 0); i++);
+
+      if (yc[i] > (xc[i] || 0)) e--;
+
+      if (s < 0) {
+        qc.push(1);
+        more = true;
+      } else {
+        xL = xc.length;
+        yL = yc.length;
+        i = 0;
+        s += 2;
+
+        // Normalise xc and yc so highest order digit of yc is >= base / 2.
+
+        n = mathfloor(base / (yc[0] + 1));
+
+        // Not necessary, but to handle odd bases where yc[0] == (base / 2) - 1.
+        // if (n > 1 || n++ == 1 && yc[0] < base / 2) {
+        if (n > 1) {
+          yc = multiply(yc, n, base);
+          xc = multiply(xc, n, base);
+          yL = yc.length;
+          xL = xc.length;
+        }
+
+        xi = yL;
+        rem = xc.slice(0, yL);
+        remL = rem.length;
+
+        // Add zeros to make remainder as long as divisor.
+        for (; remL < yL; rem[remL++] = 0);
+        yz = yc.slice();
+        yz = [0].concat(yz);
+        yc0 = yc[0];
+        if (yc[1] >= base / 2) yc0++;
+        // Not necessary, but to prevent trial digit n > base, when using base 3.
+        // else if (base == 3 && yc0 == 1) yc0 = 1 + 1e-15;
+
+        do {
+          n = 0;
+
+          // Compare divisor and remainder.
+          cmp = compare(yc, rem, yL, remL);
+
+          // If divisor < remainder.
+          if (cmp < 0) {
+
+            // Calculate trial digit, n.
+
+            rem0 = rem[0];
+            if (yL != remL) rem0 = rem0 * base + (rem[1] || 0);
+
+            // n is how many times the divisor goes into the current remainder.
+            n = mathfloor(rem0 / yc0);
+
+            //  Algorithm:
+            //  product = divisor multiplied by trial digit (n).
+            //  Compare product and remainder.
+            //  If product is greater than remainder:
+            //    Subtract divisor from product, decrement trial digit.
+            //  Subtract product from remainder.
+            //  If product was less than remainder at the last compare:
+            //    Compare new remainder and divisor.
+            //    If remainder is greater than divisor:
+            //      Subtract divisor from remainder, increment trial digit.
+
+            if (n > 1) {
+
+              // n may be > base only when base is 3.
+              if (n >= base) n = base - 1;
+
+              // product = divisor * trial digit.
+              prod = multiply(yc, n, base);
+              prodL = prod.length;
+              remL = rem.length;
+
+              // Compare product and remainder.
+              // If product > remainder then trial digit n too high.
+              // n is 1 too high about 5% of the time, and is not known to have
+              // ever been more than 1 too high.
+              while (compare(prod, rem, prodL, remL) == 1) {
+                n--;
+
+                // Subtract divisor from product.
+                subtract(prod, yL < prodL ? yz : yc, prodL, base);
+                prodL = prod.length;
+                cmp = 1;
+              }
+            } else {
+
+              // n is 0 or 1, cmp is -1.
+              // If n is 0, there is no need to compare yc and rem again below,
+              // so change cmp to 1 to avoid it.
+              // If n is 1, leave cmp as -1, so yc and rem are compared again.
+              if (n == 0) {
+
+                // divisor < remainder, so n must be at least 1.
+                cmp = n = 1;
+              }
+
+              // product = divisor
+              prod = yc.slice();
+              prodL = prod.length;
+            }
+
+            if (prodL < remL) prod = [0].concat(prod);
+
+            // Subtract product from remainder.
+            subtract(rem, prod, remL, base);
+            remL = rem.length;
+
+             // If product was < remainder.
+            if (cmp == -1) {
+
+              // Compare divisor and new remainder.
+              // If divisor < new remainder, subtract divisor from remainder.
+              // Trial digit n too low.
+              // n is 1 too low about 5% of the time, and very rarely 2 too low.
+              while (compare(yc, rem, yL, remL) < 1) {
+                n++;
+
+                // Subtract divisor from remainder.
+                subtract(rem, yL < remL ? yz : yc, remL, base);
+                remL = rem.length;
+              }
+            }
+          } else if (cmp === 0) {
+            n++;
+            rem = [0];
+          } // else cmp === 1 and n will be 0
+
+          // Add the next digit, n, to the result array.
+          qc[i++] = n;
+
+          // Update the remainder.
+          if (rem[0]) {
+            rem[remL++] = xc[xi] || 0;
+          } else {
+            rem = [xc[xi]];
+            remL = 1;
+          }
+        } while ((xi++ < xL || rem[0] != null) && s--);
+
+        more = rem[0] != null;
+
+        // Leading zero?
+        if (!qc[0]) qc.splice(0, 1);
+      }
+
+      if (base == BASE) {
+
+        // To calculate q.e, first get the number of digits of qc[0].
+        for (i = 1, s = qc[0]; s >= 10; s /= 10, i++);
+
+        round(q, dp + (q.e = i + e * LOG_BASE - 1) + 1, rm, more);
+
+      // Caller is convertBase.
+      } else {
+        q.e = e;
+        q.r = +more;
+      }
+
+      return q;
+    };
+  })();
+
+
+  /*
+   * Return a string representing the value of BigNumber n in fixed-point or exponential
+   * notation rounded to the specified decimal places or significant digits.
+   *
+   * n: a BigNumber.
+   * i: the index of the last digit required (i.e. the digit that may be rounded up).
+   * rm: the rounding mode.
+   * id: 1 (toExponential) or 2 (toPrecision).
+   */
+  function format(n, i, rm, id) {
+    var c0, e, ne, len, str;
+
+    if (rm == null) rm = ROUNDING_MODE;
+    else intCheck(rm, 0, 8);
+
+    if (!n.c) return n.toString();
+
+    c0 = n.c[0];
+    ne = n.e;
+
+    if (i == null) {
+      str = coeffToString(n.c);
+      str = id == 1 || id == 2 && ne <= TO_EXP_NEG
+       ? toExponential(str, ne)
+       : toFixedPoint(str, ne, '0');
+    } else {
+      n = round(new BigNumber(n), i, rm);
+
+      // n.e may have changed if the value was rounded up.
+      e = n.e;
+
+      str = coeffToString(n.c);
+      len = str.length;
+
+      // toPrecision returns exponential notation if the number of significant digits
+      // specified is less than the number of digits necessary to represent the integer
+      // part of the value in fixed-point notation.
+
+      // Exponential notation.
+      if (id == 1 || id == 2 && (i <= e || e <= TO_EXP_NEG)) {
+
+        // Append zeros?
+        for (; len < i; str += '0', len++);
+        str = toExponential(str, e);
+
+      // Fixed-point notation.
+      } else {
+        i -= ne;
+        str = toFixedPoint(str, e, '0');
+
+        // Append zeros?
+        if (e + 1 > len) {
+          if (--i > 0) for (str += '.'; i--; str += '0');
         } else {
-            len = str.length;
+          i += e - len;
+          if (i > 0) {
+            if (e + 1 == len) str += '.';
+            for (; i--; str += '0');
+          }
+        }
+      }
+    }
 
-            // Append zeros.
-            if ( ++e > len ) {
-                for ( z = '0', e -= len; --e; z += '0' );
-                str += z;
-            } else if ( e < len ) {
-                str = str.slice( 0, e ) + '.' + str.slice(e);
-            }
+    return n.s < 0 && c0 ? '-' + str : str;
+  }
+
+
+  // Handle BigNumber.max and BigNumber.min.
+  function maxOrMin(args, method) {
+    var m, n,
+      i = 0;
+
+    if (isArray(args[0])) args = args[0];
+    m = new BigNumber(args[0]);
+
+    for (; ++i < args.length;) {
+      n = new BigNumber(args[i]);
+
+      // If any number is NaN, return NaN.
+      if (!n.s) {
+        m = n;
+        break;
+      } else if (method.call(m, n)) {
+        m = n;
+      }
+    }
+
+    return m;
+  }
+
+
+  /*
+   * Strip trailing zeros, calculate base 10 exponent and check against MIN_EXP and MAX_EXP.
+   * Called by minus, plus and times.
+   */
+  function normalise(n, c, e) {
+    var i = 1,
+      j = c.length;
+
+     // Remove trailing zeros.
+    for (; !c[--j]; c.pop());
+
+    // Calculate the base 10 exponent. First get the number of digits of c[0].
+    for (j = c[0]; j >= 10; j /= 10, i++);
+
+    // Overflow?
+    if ((e = i + e * LOG_BASE - 1) > MAX_EXP) {
+
+      // Infinity.
+      n.c = n.e = null;
+
+    // Underflow?
+    } else if (e < MIN_EXP) {
+
+      // Zero.
+      n.c = [n.e = 0];
+    } else {
+      n.e = e;
+      n.c = c;
+    }
+
+    return n;
+  }
+
+
+  // Handle values that fail the validity test in BigNumber.
+  parseNumeric = (function () {
+    var basePrefix = /^(-?)0([xbo])(?=\w[\w.]*$)/i,
+      dotAfter = /^([^.]+)\.$/,
+      dotBefore = /^\.([^.]+)$/,
+      isInfinityOrNaN = /^-?(Infinity|NaN)$/,
+      whitespaceOrPlus = /^\s*\+(?=[\w.])|^\s+|\s+$/g;
+
+    return function (x, str, isNum, b) {
+      var base,
+        s = isNum ? str : str.replace(whitespaceOrPlus, '');
+
+      // No exception on ±Infinity or NaN.
+      if (isInfinityOrNaN.test(s)) {
+        x.s = isNaN(s) ? null : s < 0 ? -1 : 1;
+        x.c = x.e = null;
+      } else {
+        if (!isNum) {
+
+          // basePrefix = /^(-?)0([xbo])(?=\w[\w.]*$)/i
+          s = s.replace(basePrefix, function (m, p1, p2) {
+            base = (p2 = p2.toLowerCase()) == 'x' ? 16 : p2 == 'b' ? 2 : 8;
+            return !b || b == base ? p1 : m;
+          });
+
+          if (b) {
+            base = b;
+
+            // E.g. '1.' to '1', '.1' to '0.1'
+            s = s.replace(dotAfter, '$1').replace(dotBefore, '0.$1');
+          }
+
+          if (str != s) return new BigNumber(s, base);
         }
 
-        return str;
+        // '[BigNumber Error] Not a number: {n}'
+        // '[BigNumber Error] Not a base {b} number: {n}'
+        if (BigNumber.DEBUG) {
+          throw Error
+            (bignumberError + 'Not a' + (b ? ' base ' + b : '') + ' number: ' + str);
+        }
+
+        // NaN
+        x.c = x.e = x.s = null;
+      }
+    }
+  })();
+
+
+  /*
+   * Round x to sd significant digits using rounding mode rm. Check for over/under-flow.
+   * If r is truthy, it is known that there are more digits after the rounding digit.
+   */
+  function round(x, sd, rm, r) {
+    var d, i, j, k, n, ni, rd,
+      xc = x.c,
+      pows10 = POWS_TEN;
+
+    // if x is not Infinity or NaN...
+    if (xc) {
+
+      // rd is the rounding digit, i.e. the digit after the digit that may be rounded up.
+      // n is a base 1e14 number, the value of the element of array x.c containing rd.
+      // ni is the index of n within x.c.
+      // d is the number of digits of n.
+      // i is the index of rd within n including leading zeros.
+      // j is the actual index of rd within n (if < 0, rd is a leading zero).
+      out: {
+
+        // Get the number of digits of the first element of xc.
+        for (d = 1, k = xc[0]; k >= 10; k /= 10, d++);
+        i = sd - d;
+
+        // If the rounding digit is in the first element of xc...
+        if (i < 0) {
+          i += LOG_BASE;
+          j = sd;
+          n = xc[ni = 0];
+
+          // Get the rounding digit at index j of n.
+          rd = n / pows10[d - j - 1] % 10 | 0;
+        } else {
+          ni = mathceil((i + 1) / LOG_BASE);
+
+          if (ni >= xc.length) {
+
+            if (r) {
+
+              // Needed by sqrt.
+              for (; xc.length <= ni; xc.push(0));
+              n = rd = 0;
+              d = 1;
+              i %= LOG_BASE;
+              j = i - LOG_BASE + 1;
+            } else {
+              break out;
+            }
+          } else {
+            n = k = xc[ni];
+
+            // Get the number of digits of n.
+            for (d = 1; k >= 10; k /= 10, d++);
+
+            // Get the index of rd within n.
+            i %= LOG_BASE;
+
+            // Get the index of rd within n, adjusted for leading zeros.
+            // The number of leading zeros of n is given by LOG_BASE - d.
+            j = i - LOG_BASE + d;
+
+            // Get the rounding digit at index j of n.
+            rd = j < 0 ? 0 : n / pows10[d - j - 1] % 10 | 0;
+          }
+        }
+
+        r = r || sd < 0 ||
+
+        // Are there any non-zero digits after the rounding digit?
+        // The expression  n % pows10[d - j - 1]  returns all digits of n to the right
+        // of the digit at j, e.g. if n is 908714 and j is 2, the expression gives 714.
+         xc[ni + 1] != null || (j < 0 ? n : n % pows10[d - j - 1]);
+
+        r = rm < 4
+         ? (rd || r) && (rm == 0 || rm == (x.s < 0 ? 3 : 2))
+         : rd > 5 || rd == 5 && (rm == 4 || r || rm == 6 &&
+
+          // Check whether the digit to the left of the rounding digit is odd.
+          ((i > 0 ? j > 0 ? n / pows10[d - j] : 0 : xc[ni - 1]) % 10) & 1 ||
+           rm == (x.s < 0 ? 8 : 7));
+
+        if (sd < 1 || !xc[0]) {
+          xc.length = 0;
+
+          if (r) {
+
+            // Convert sd to decimal places.
+            sd -= x.e + 1;
+
+            // 1, 0.1, 0.01, 0.001, 0.0001 etc.
+            xc[0] = pows10[(LOG_BASE - sd % LOG_BASE) % LOG_BASE];
+            x.e = -sd || 0;
+          } else {
+
+            // Zero.
+            xc[0] = x.e = 0;
+          }
+
+          return x;
+        }
+
+        // Remove excess digits.
+        if (i == 0) {
+          xc.length = ni;
+          k = 1;
+          ni--;
+        } else {
+          xc.length = ni + 1;
+          k = pows10[LOG_BASE - i];
+
+          // E.g. 56700 becomes 56000 if 7 is the rounding digit.
+          // j > 0 means i > number of leading zeros of n.
+          xc[ni] = j > 0 ? mathfloor(n / pows10[d - j] % pows10[j]) * k : 0;
+        }
+
+        // Round up?
+        if (r) {
+
+          for (; ;) {
+
+            // If the digit to be rounded up is in the first element of xc...
+            if (ni == 0) {
+
+              // i will be the length of xc[0] before k is added.
+              for (i = 1, j = xc[0]; j >= 10; j /= 10, i++);
+              j = xc[0] += k;
+              for (k = 1; j >= 10; j /= 10, k++);
+
+              // if i != k the length has increased.
+              if (i != k) {
+                x.e++;
+                if (xc[0] == BASE) xc[0] = 1;
+              }
+
+              break;
+            } else {
+              xc[ni] += k;
+              if (xc[ni] != BASE) break;
+              xc[ni--] = 0;
+              k = 1;
+            }
+          }
+        }
+
+        // Remove trailing zeros.
+        for (i = xc.length; xc[--i] === 0; xc.pop());
+      }
+
+      // Overflow? Infinity.
+      if (x.e > MAX_EXP) {
+        x.c = x.e = null;
+
+      // Underflow? Zero.
+      } else if (x.e < MIN_EXP) {
+        x.c = [x.e = 0];
+      }
     }
 
+    return x;
+  }
 
-    function truncate(n) {
-        n = parseFloat(n);
-        return n < 0 ? mathceil(n) : mathfloor(n);
+
+  // PROTOTYPE/INSTANCE METHODS
+
+
+  /*
+   * Return a new BigNumber whose value is the absolute value of this BigNumber.
+   */
+  P.absoluteValue = P.abs = function () {
+    var x = new BigNumber(this);
+    if (x.s < 0) x.s = 1;
+    return x;
+  };
+
+
+  /*
+   * Return
+   *   1 if the value of this BigNumber is greater than the value of BigNumber(y, b),
+   *   -1 if the value of this BigNumber is less than the value of BigNumber(y, b),
+   *   0 if they have the same value,
+   *   or null if the value of either is NaN.
+   */
+  P.comparedTo = function (y, b) {
+    return compare(this, new BigNumber(y, b));
+  };
+
+
+  /*
+   * If dp is undefined or null or true or false, return the number of decimal places of the
+   * value of this BigNumber, or null if the value of this BigNumber is ±Infinity or NaN.
+   *
+   * Otherwise, if dp is a number, return a new BigNumber whose value is the value of this
+   * BigNumber rounded to a maximum of dp decimal places using rounding mode rm, or
+   * ROUNDING_MODE if rm is omitted.
+   *
+   * [dp] {number} Decimal places: integer, 0 to MAX inclusive.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {dp|rm}'
+   */
+  P.decimalPlaces = P.dp = function (dp, rm) {
+    var c, n, v,
+      x = this;
+
+    if (dp != null) {
+      intCheck(dp, 0, MAX);
+      if (rm == null) rm = ROUNDING_MODE;
+      else intCheck(rm, 0, 8);
+
+      return round(new BigNumber(x), dp + x.e + 1, rm);
     }
 
+    if (!(c = x.c)) return null;
+    n = ((v = c.length - 1) - bitFloor(this.e / LOG_BASE)) * LOG_BASE;
 
-    // EXPORT
+    // Subtract the number of trailing zeros of the last number.
+    if (v = c[v]) for (; v % 10 == 0; v /= 10, n--);
+    if (n < 0) n = 0;
+
+    return n;
+  };
 
 
-    BigNumber = constructorFactory();
-    BigNumber['default'] = BigNumber.BigNumber = BigNumber;
+  /*
+   *  n / 0 = I
+   *  n / N = N
+   *  n / I = 0
+   *  0 / n = 0
+   *  0 / 0 = N
+   *  0 / N = N
+   *  0 / I = 0
+   *  N / n = N
+   *  N / 0 = N
+   *  N / N = N
+   *  N / I = N
+   *  I / n = I
+   *  I / 0 = I
+   *  I / N = N
+   *  I / I = N
+   *
+   * Return a new BigNumber whose value is the value of this BigNumber divided by the value of
+   * BigNumber(y, b), rounded according to DECIMAL_PLACES and ROUNDING_MODE.
+   */
+  P.dividedBy = P.div = function (y, b) {
+    return div(this, new BigNumber(y, b), DECIMAL_PLACES, ROUNDING_MODE);
+  };
 
 
-    // AMD.
-    if ( true ) {
-        !(__WEBPACK_AMD_DEFINE_RESULT__ = (function () { return BigNumber; }).call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  /*
+   * Return a new BigNumber whose value is the integer part of dividing the value of this
+   * BigNumber by the value of BigNumber(y, b).
+   */
+  P.dividedToIntegerBy = P.idiv = function (y, b) {
+    return div(this, new BigNumber(y, b), 0, 1);
+  };
 
-    // Node.js and other environments that support module.exports.
-    } else {}
-})(this);
+
+  /*
+   * Return a BigNumber whose value is the value of this BigNumber exponentiated by n.
+   *
+   * If m is present, return the result modulo m.
+   * If n is negative round according to DECIMAL_PLACES and ROUNDING_MODE.
+   * If POW_PRECISION is non-zero and m is not present, round to POW_PRECISION using ROUNDING_MODE.
+   *
+   * The modular power operation works efficiently when x, n, and m are integers, otherwise it
+   * is equivalent to calculating x.exponentiatedBy(n).modulo(m) with a POW_PRECISION of 0.
+   *
+   * n {number|string|BigNumber} The exponent. An integer.
+   * [m] {number|string|BigNumber} The modulus.
+   *
+   * '[BigNumber Error] Exponent not an integer: {n}'
+   */
+  P.exponentiatedBy = P.pow = function (n, m) {
+    var half, isModExp, k, more, nIsBig, nIsNeg, nIsOdd, y,
+      x = this;
+
+    n = new BigNumber(n);
+
+    // Allow NaN and ±Infinity, but not other non-integers.
+    if (n.c && !n.isInteger()) {
+      throw Error
+        (bignumberError + 'Exponent not an integer: ' + n);
+    }
+
+    if (m != null) m = new BigNumber(m);
+
+    // Exponent of MAX_SAFE_INTEGER is 15.
+    nIsBig = n.e > 14;
+
+    // If x is NaN, ±Infinity, ±0 or ±1, or n is ±Infinity, NaN or ±0.
+    if (!x.c || !x.c[0] || x.c[0] == 1 && !x.e && x.c.length == 1 || !n.c || !n.c[0]) {
+
+      // The sign of the result of pow when x is negative depends on the evenness of n.
+      // If +n overflows to ±Infinity, the evenness of n would be not be known.
+      y = new BigNumber(Math.pow(+x.valueOf(), nIsBig ? 2 - isOdd(n) : +n));
+      return m ? y.mod(m) : y;
+    }
+
+    nIsNeg = n.s < 0;
+
+    if (m) {
+
+      // x % m returns NaN if abs(m) is zero, or m is NaN.
+      if (m.c ? !m.c[0] : !m.s) return new BigNumber(NaN);
+
+      isModExp = !nIsNeg && x.isInteger() && m.isInteger();
+
+      if (isModExp) x = x.mod(m);
+
+    // Overflow to ±Infinity: >=2**1e10 or >=1.0000024**1e15.
+    // Underflow to ±0: <=0.79**1e10 or <=0.9999975**1e15.
+    } else if (n.e > 9 && (x.e > 0 || x.e < -1 || (x.e == 0
+      // [1, 240000000]
+      ? x.c[0] > 1 || nIsBig && x.c[1] >= 24e7
+      // [80000000000000]  [99999750000000]
+      : x.c[0] < 8e13 || nIsBig && x.c[0] <= 9999975e7))) {
+
+      // If x is negative and n is odd, k = -0, else k = 0.
+      k = x.s < 0 && isOdd(n) ? -0 : 0;
+
+      // If x >= 1, k = ±Infinity.
+      if (x.e > -1) k = 1 / k;
+
+      // If n is negative return ±0, else return ±Infinity.
+      return new BigNumber(nIsNeg ? 1 / k : k);
+
+    } else if (POW_PRECISION) {
+
+      // Truncating each coefficient array to a length of k after each multiplication
+      // equates to truncating significant digits to POW_PRECISION + [28, 41],
+      // i.e. there will be a minimum of 28 guard digits retained.
+      k = mathceil(POW_PRECISION / LOG_BASE + 2);
+    }
+
+    if (nIsBig) {
+      half = new BigNumber(0.5);
+      nIsOdd = isOdd(n);
+    } else {
+      nIsOdd = n % 2;
+    }
+
+    if (nIsNeg) n.s = 1;
+
+    y = new BigNumber(ONE);
+
+    // Performs 54 loop iterations for n of 9007199254740991.
+    for (; ;) {
+
+      if (nIsOdd) {
+        y = y.times(x);
+        if (!y.c) break;
+
+        if (k) {
+          if (y.c.length > k) y.c.length = k;
+        } else if (isModExp) {
+          y = y.mod(m);    //y = y.minus(div(y, m, 0, MODULO_MODE).times(m));
+        }
+      }
+
+      if (nIsBig) {
+        n = n.times(half);
+        round(n, n.e + 1, 1);
+        if (!n.c[0]) break;
+        nIsBig = n.e > 14;
+        nIsOdd = isOdd(n);
+      } else {
+        n = mathfloor(n / 2);
+        if (!n) break;
+        nIsOdd = n % 2;
+      }
+
+      x = x.times(x);
+
+      if (k) {
+        if (x.c && x.c.length > k) x.c.length = k;
+      } else if (isModExp) {
+        x = x.mod(m);    //x = x.minus(div(x, m, 0, MODULO_MODE).times(m));
+      }
+    }
+
+    if (isModExp) return y;
+    if (nIsNeg) y = ONE.div(y);
+
+    return m ? y.mod(m) : k ? round(y, POW_PRECISION, ROUNDING_MODE, more) : y;
+  };
+
+
+  /*
+   * Return a new BigNumber whose value is the value of this BigNumber rounded to an integer
+   * using rounding mode rm, or ROUNDING_MODE if rm is omitted.
+   *
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {rm}'
+   */
+  P.integerValue = function (rm) {
+    var n = new BigNumber(this);
+    if (rm == null) rm = ROUNDING_MODE;
+    else intCheck(rm, 0, 8);
+    return round(n, n.e + 1, rm);
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is equal to the value of BigNumber(y, b),
+   * otherwise return false.
+   */
+  P.isEqualTo = P.eq = function (y, b) {
+    return compare(this, new BigNumber(y, b)) === 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is a finite number, otherwise return false.
+   */
+  P.isFinite = function () {
+    return !!this.c;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is greater than the value of BigNumber(y, b),
+   * otherwise return false.
+   */
+  P.isGreaterThan = P.gt = function (y, b) {
+    return compare(this, new BigNumber(y, b)) > 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is greater than or equal to the value of
+   * BigNumber(y, b), otherwise return false.
+   */
+  P.isGreaterThanOrEqualTo = P.gte = function (y, b) {
+    return (b = compare(this, new BigNumber(y, b))) === 1 || b === 0;
+
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is an integer, otherwise return false.
+   */
+  P.isInteger = function () {
+    return !!this.c && bitFloor(this.e / LOG_BASE) > this.c.length - 2;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is less than the value of BigNumber(y, b),
+   * otherwise return false.
+   */
+  P.isLessThan = P.lt = function (y, b) {
+    return compare(this, new BigNumber(y, b)) < 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is less than or equal to the value of
+   * BigNumber(y, b), otherwise return false.
+   */
+  P.isLessThanOrEqualTo = P.lte = function (y, b) {
+    return (b = compare(this, new BigNumber(y, b))) === -1 || b === 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is NaN, otherwise return false.
+   */
+  P.isNaN = function () {
+    return !this.s;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is negative, otherwise return false.
+   */
+  P.isNegative = function () {
+    return this.s < 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is positive, otherwise return false.
+   */
+  P.isPositive = function () {
+    return this.s > 0;
+  };
+
+
+  /*
+   * Return true if the value of this BigNumber is 0 or -0, otherwise return false.
+   */
+  P.isZero = function () {
+    return !!this.c && this.c[0] == 0;
+  };
+
+
+  /*
+   *  n - 0 = n
+   *  n - N = N
+   *  n - I = -I
+   *  0 - n = -n
+   *  0 - 0 = 0
+   *  0 - N = N
+   *  0 - I = -I
+   *  N - n = N
+   *  N - 0 = N
+   *  N - N = N
+   *  N - I = N
+   *  I - n = I
+   *  I - 0 = I
+   *  I - N = N
+   *  I - I = N
+   *
+   * Return a new BigNumber whose value is the value of this BigNumber minus the value of
+   * BigNumber(y, b).
+   */
+  P.minus = function (y, b) {
+    var i, j, t, xLTy,
+      x = this,
+      a = x.s;
+
+    y = new BigNumber(y, b);
+    b = y.s;
+
+    // Either NaN?
+    if (!a || !b) return new BigNumber(NaN);
+
+    // Signs differ?
+    if (a != b) {
+      y.s = -b;
+      return x.plus(y);
+    }
+
+    var xe = x.e / LOG_BASE,
+      ye = y.e / LOG_BASE,
+      xc = x.c,
+      yc = y.c;
+
+    if (!xe || !ye) {
+
+      // Either Infinity?
+      if (!xc || !yc) return xc ? (y.s = -b, y) : new BigNumber(yc ? x : NaN);
+
+      // Either zero?
+      if (!xc[0] || !yc[0]) {
+
+        // Return y if y is non-zero, x if x is non-zero, or zero if both are zero.
+        return yc[0] ? (y.s = -b, y) : new BigNumber(xc[0] ? x :
+
+         // IEEE 754 (2008) 6.3: n - n = -0 when rounding to -Infinity
+         ROUNDING_MODE == 3 ? -0 : 0);
+      }
+    }
+
+    xe = bitFloor(xe);
+    ye = bitFloor(ye);
+    xc = xc.slice();
+
+    // Determine which is the bigger number.
+    if (a = xe - ye) {
+
+      if (xLTy = a < 0) {
+        a = -a;
+        t = xc;
+      } else {
+        ye = xe;
+        t = yc;
+      }
+
+      t.reverse();
+
+      // Prepend zeros to equalise exponents.
+      for (b = a; b--; t.push(0));
+      t.reverse();
+    } else {
+
+      // Exponents equal. Check digit by digit.
+      j = (xLTy = (a = xc.length) < (b = yc.length)) ? a : b;
+
+      for (a = b = 0; b < j; b++) {
+
+        if (xc[b] != yc[b]) {
+          xLTy = xc[b] < yc[b];
+          break;
+        }
+      }
+    }
+
+    // x < y? Point xc to the array of the bigger number.
+    if (xLTy) t = xc, xc = yc, yc = t, y.s = -y.s;
+
+    b = (j = yc.length) - (i = xc.length);
+
+    // Append zeros to xc if shorter.
+    // No need to add zeros to yc if shorter as subtract only needs to start at yc.length.
+    if (b > 0) for (; b--; xc[i++] = 0);
+    b = BASE - 1;
+
+    // Subtract yc from xc.
+    for (; j > a;) {
+
+      if (xc[--j] < yc[j]) {
+        for (i = j; i && !xc[--i]; xc[i] = b);
+        --xc[i];
+        xc[j] += BASE;
+      }
+
+      xc[j] -= yc[j];
+    }
+
+    // Remove leading zeros and adjust exponent accordingly.
+    for (; xc[0] == 0; xc.splice(0, 1), --ye);
+
+    // Zero?
+    if (!xc[0]) {
+
+      // Following IEEE 754 (2008) 6.3,
+      // n - n = +0  but  n - n = -0  when rounding towards -Infinity.
+      y.s = ROUNDING_MODE == 3 ? -1 : 1;
+      y.c = [y.e = 0];
+      return y;
+    }
+
+    // No need to check for Infinity as +x - +y != Infinity && -x - -y != Infinity
+    // for finite x and y.
+    return normalise(y, xc, ye);
+  };
+
+
+  /*
+   *   n % 0 =  N
+   *   n % N =  N
+   *   n % I =  n
+   *   0 % n =  0
+   *  -0 % n = -0
+   *   0 % 0 =  N
+   *   0 % N =  N
+   *   0 % I =  0
+   *   N % n =  N
+   *   N % 0 =  N
+   *   N % N =  N
+   *   N % I =  N
+   *   I % n =  N
+   *   I % 0 =  N
+   *   I % N =  N
+   *   I % I =  N
+   *
+   * Return a new BigNumber whose value is the value of this BigNumber modulo the value of
+   * BigNumber(y, b). The result depends on the value of MODULO_MODE.
+   */
+  P.modulo = P.mod = function (y, b) {
+    var q, s,
+      x = this;
+
+    y = new BigNumber(y, b);
+
+    // Return NaN if x is Infinity or NaN, or y is NaN or zero.
+    if (!x.c || !y.s || y.c && !y.c[0]) {
+      return new BigNumber(NaN);
+
+    // Return x if y is Infinity or x is zero.
+    } else if (!y.c || x.c && !x.c[0]) {
+      return new BigNumber(x);
+    }
+
+    if (MODULO_MODE == 9) {
+
+      // Euclidian division: q = sign(y) * floor(x / abs(y))
+      // r = x - qy    where  0 <= r < abs(y)
+      s = y.s;
+      y.s = 1;
+      q = div(x, y, 0, 3);
+      y.s = s;
+      q.s *= s;
+    } else {
+      q = div(x, y, 0, MODULO_MODE);
+    }
+
+    y = x.minus(q.times(y));
+
+    // To match JavaScript %, ensure sign of zero is sign of dividend.
+    if (!y.c[0] && MODULO_MODE == 1) y.s = x.s;
+
+    return y;
+  };
+
+
+  /*
+   *  n * 0 = 0
+   *  n * N = N
+   *  n * I = I
+   *  0 * n = 0
+   *  0 * 0 = 0
+   *  0 * N = N
+   *  0 * I = N
+   *  N * n = N
+   *  N * 0 = N
+   *  N * N = N
+   *  N * I = N
+   *  I * n = I
+   *  I * 0 = N
+   *  I * N = N
+   *  I * I = I
+   *
+   * Return a new BigNumber whose value is the value of this BigNumber multiplied by the value
+   * of BigNumber(y, b).
+   */
+  P.multipliedBy = P.times = function (y, b) {
+    var c, e, i, j, k, m, xcL, xlo, xhi, ycL, ylo, yhi, zc,
+      base, sqrtBase,
+      x = this,
+      xc = x.c,
+      yc = (y = new BigNumber(y, b)).c;
+
+    // Either NaN, ±Infinity or ±0?
+    if (!xc || !yc || !xc[0] || !yc[0]) {
+
+      // Return NaN if either is NaN, or one is 0 and the other is Infinity.
+      if (!x.s || !y.s || xc && !xc[0] && !yc || yc && !yc[0] && !xc) {
+        y.c = y.e = y.s = null;
+      } else {
+        y.s *= x.s;
+
+        // Return ±Infinity if either is ±Infinity.
+        if (!xc || !yc) {
+          y.c = y.e = null;
+
+        // Return ±0 if either is ±0.
+        } else {
+          y.c = [0];
+          y.e = 0;
+        }
+      }
+
+      return y;
+    }
+
+    e = bitFloor(x.e / LOG_BASE) + bitFloor(y.e / LOG_BASE);
+    y.s *= x.s;
+    xcL = xc.length;
+    ycL = yc.length;
+
+    // Ensure xc points to longer array and xcL to its length.
+    if (xcL < ycL) zc = xc, xc = yc, yc = zc, i = xcL, xcL = ycL, ycL = i;
+
+    // Initialise the result array with zeros.
+    for (i = xcL + ycL, zc = []; i--; zc.push(0));
+
+    base = BASE;
+    sqrtBase = SQRT_BASE;
+
+    for (i = ycL; --i >= 0;) {
+      c = 0;
+      ylo = yc[i] % sqrtBase;
+      yhi = yc[i] / sqrtBase | 0;
+
+      for (k = xcL, j = i + k; j > i;) {
+        xlo = xc[--k] % sqrtBase;
+        xhi = xc[k] / sqrtBase | 0;
+        m = yhi * xlo + xhi * ylo;
+        xlo = ylo * xlo + ((m % sqrtBase) * sqrtBase) + zc[j] + c;
+        c = (xlo / base | 0) + (m / sqrtBase | 0) + yhi * xhi;
+        zc[j--] = xlo % base;
+      }
+
+      zc[j] = c;
+    }
+
+    if (c) {
+      ++e;
+    } else {
+      zc.splice(0, 1);
+    }
+
+    return normalise(y, zc, e);
+  };
+
+
+  /*
+   * Return a new BigNumber whose value is the value of this BigNumber negated,
+   * i.e. multiplied by -1.
+   */
+  P.negated = function () {
+    var x = new BigNumber(this);
+    x.s = -x.s || null;
+    return x;
+  };
+
+
+  /*
+   *  n + 0 = n
+   *  n + N = N
+   *  n + I = I
+   *  0 + n = n
+   *  0 + 0 = 0
+   *  0 + N = N
+   *  0 + I = I
+   *  N + n = N
+   *  N + 0 = N
+   *  N + N = N
+   *  N + I = N
+   *  I + n = I
+   *  I + 0 = I
+   *  I + N = N
+   *  I + I = I
+   *
+   * Return a new BigNumber whose value is the value of this BigNumber plus the value of
+   * BigNumber(y, b).
+   */
+  P.plus = function (y, b) {
+    var t,
+      x = this,
+      a = x.s;
+
+    y = new BigNumber(y, b);
+    b = y.s;
+
+    // Either NaN?
+    if (!a || !b) return new BigNumber(NaN);
+
+    // Signs differ?
+     if (a != b) {
+      y.s = -b;
+      return x.minus(y);
+    }
+
+    var xe = x.e / LOG_BASE,
+      ye = y.e / LOG_BASE,
+      xc = x.c,
+      yc = y.c;
+
+    if (!xe || !ye) {
+
+      // Return ±Infinity if either ±Infinity.
+      if (!xc || !yc) return new BigNumber(a / 0);
+
+      // Either zero?
+      // Return y if y is non-zero, x if x is non-zero, or zero if both are zero.
+      if (!xc[0] || !yc[0]) return yc[0] ? y : new BigNumber(xc[0] ? x : a * 0);
+    }
+
+    xe = bitFloor(xe);
+    ye = bitFloor(ye);
+    xc = xc.slice();
+
+    // Prepend zeros to equalise exponents. Faster to use reverse then do unshifts.
+    if (a = xe - ye) {
+      if (a > 0) {
+        ye = xe;
+        t = yc;
+      } else {
+        a = -a;
+        t = xc;
+      }
+
+      t.reverse();
+      for (; a--; t.push(0));
+      t.reverse();
+    }
+
+    a = xc.length;
+    b = yc.length;
+
+    // Point xc to the longer array, and b to the shorter length.
+    if (a - b < 0) t = yc, yc = xc, xc = t, b = a;
+
+    // Only start adding at yc.length - 1 as the further digits of xc can be ignored.
+    for (a = 0; b;) {
+      a = (xc[--b] = xc[b] + yc[b] + a) / BASE | 0;
+      xc[b] = BASE === xc[b] ? 0 : xc[b] % BASE;
+    }
+
+    if (a) {
+      xc = [a].concat(xc);
+      ++ye;
+    }
+
+    // No need to check for zero, as +x + +y != 0 && -x + -y != 0
+    // ye = MAX_EXP + 1 possible
+    return normalise(y, xc, ye);
+  };
+
+
+  /*
+   * If sd is undefined or null or true or false, return the number of significant digits of
+   * the value of this BigNumber, or null if the value of this BigNumber is ±Infinity or NaN.
+   * If sd is true include integer-part trailing zeros in the count.
+   *
+   * Otherwise, if sd is a number, return a new BigNumber whose value is the value of this
+   * BigNumber rounded to a maximum of sd significant digits using rounding mode rm, or
+   * ROUNDING_MODE if rm is omitted.
+   *
+   * sd {number|boolean} number: significant digits: integer, 1 to MAX inclusive.
+   *                     boolean: whether to count integer-part trailing zeros: true or false.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {sd|rm}'
+   */
+  P.precision = P.sd = function (sd, rm) {
+    var c, n, v,
+      x = this;
+
+    if (sd != null && sd !== !!sd) {
+      intCheck(sd, 1, MAX);
+      if (rm == null) rm = ROUNDING_MODE;
+      else intCheck(rm, 0, 8);
+
+      return round(new BigNumber(x), sd, rm);
+    }
+
+    if (!(c = x.c)) return null;
+    v = c.length - 1;
+    n = v * LOG_BASE + 1;
+
+    if (v = c[v]) {
+
+      // Subtract the number of trailing zeros of the last element.
+      for (; v % 10 == 0; v /= 10, n--);
+
+      // Add the number of digits of the first element.
+      for (v = c[0]; v >= 10; v /= 10, n++);
+    }
+
+    if (sd && x.e + 1 > n) n = x.e + 1;
+
+    return n;
+  };
+
+
+  /*
+   * Return a new BigNumber whose value is the value of this BigNumber shifted by k places
+   * (powers of 10). Shift to the right if n > 0, and to the left if n < 0.
+   *
+   * k {number} Integer, -MAX_SAFE_INTEGER to MAX_SAFE_INTEGER inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {k}'
+   */
+  P.shiftedBy = function (k) {
+    intCheck(k, -MAX_SAFE_INTEGER, MAX_SAFE_INTEGER);
+    return this.times('1e' + k);
+  };
+
+
+  /*
+   *  sqrt(-n) =  N
+   *  sqrt(N) =  N
+   *  sqrt(-I) =  N
+   *  sqrt(I) =  I
+   *  sqrt(0) =  0
+   *  sqrt(-0) = -0
+   *
+   * Return a new BigNumber whose value is the square root of the value of this BigNumber,
+   * rounded according to DECIMAL_PLACES and ROUNDING_MODE.
+   */
+  P.squareRoot = P.sqrt = function () {
+    var m, n, r, rep, t,
+      x = this,
+      c = x.c,
+      s = x.s,
+      e = x.e,
+      dp = DECIMAL_PLACES + 4,
+      half = new BigNumber('0.5');
+
+    // Negative/NaN/Infinity/zero?
+    if (s !== 1 || !c || !c[0]) {
+      return new BigNumber(!s || s < 0 && (!c || c[0]) ? NaN : c ? x : 1 / 0);
+    }
+
+    // Initial estimate.
+    s = Math.sqrt(+x);
+
+    // Math.sqrt underflow/overflow?
+    // Pass x to Math.sqrt as integer, then adjust the exponent of the result.
+    if (s == 0 || s == 1 / 0) {
+      n = coeffToString(c);
+      if ((n.length + e) % 2 == 0) n += '0';
+      s = Math.sqrt(n);
+      e = bitFloor((e + 1) / 2) - (e < 0 || e % 2);
+
+      if (s == 1 / 0) {
+        n = '1e' + e;
+      } else {
+        n = s.toExponential();
+        n = n.slice(0, n.indexOf('e') + 1) + e;
+      }
+
+      r = new BigNumber(n);
+    } else {
+      r = new BigNumber(s + '');
+    }
+
+    // Check for zero.
+    // r could be zero if MIN_EXP is changed after the this value was created.
+    // This would cause a division by zero (x/t) and hence Infinity below, which would cause
+    // coeffToString to throw.
+    if (r.c[0]) {
+      e = r.e;
+      s = e + dp;
+      if (s < 3) s = 0;
+
+      // Newton-Raphson iteration.
+      for (; ;) {
+        t = r;
+        r = half.times(t.plus(div(x, t, dp, 1)));
+
+        if (coeffToString(t.c  ).slice(0, s) === (n =
+           coeffToString(r.c)).slice(0, s)) {
+
+          // The exponent of r may here be one less than the final result exponent,
+          // e.g 0.0009999 (e-4) --> 0.001 (e-3), so adjust s so the rounding digits
+          // are indexed correctly.
+          if (r.e < e) --s;
+          n = n.slice(s - 3, s + 1);
+
+          // The 4th rounding digit may be in error by -1 so if the 4 rounding digits
+          // are 9999 or 4999 (i.e. approaching a rounding boundary) continue the
+          // iteration.
+          if (n == '9999' || !rep && n == '4999') {
+
+            // On the first iteration only, check to see if rounding up gives the
+            // exact result as the nines may infinitely repeat.
+            if (!rep) {
+              round(t, t.e + DECIMAL_PLACES + 2, 0);
+
+              if (t.times(t).eq(x)) {
+                r = t;
+                break;
+              }
+            }
+
+            dp += 4;
+            s += 4;
+            rep = 1;
+          } else {
+
+            // If rounding digits are null, 0{0,4} or 50{0,3}, check for exact
+            // result. If not, then there are further digits and m will be truthy.
+            if (!+n || !+n.slice(1) && n.charAt(0) == '5') {
+
+              // Truncate to the first rounding digit.
+              round(r, r.e + DECIMAL_PLACES + 2, 1);
+              m = !r.times(r).eq(x);
+            }
+
+            break;
+          }
+        }
+      }
+    }
+
+    return round(r, r.e + DECIMAL_PLACES + 1, ROUNDING_MODE, m);
+  };
+
+
+  /*
+   * Return a string representing the value of this BigNumber in exponential notation and
+   * rounded using ROUNDING_MODE to dp fixed decimal places.
+   *
+   * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {dp|rm}'
+   */
+  P.toExponential = function (dp, rm) {
+    if (dp != null) {
+      intCheck(dp, 0, MAX);
+      dp++;
+    }
+    return format(this, dp, rm, 1);
+  };
+
+
+  /*
+   * Return a string representing the value of this BigNumber in fixed-point notation rounding
+   * to dp fixed decimal places using rounding mode rm, or ROUNDING_MODE if rm is omitted.
+   *
+   * Note: as with JavaScript's number type, (-0).toFixed(0) is '0',
+   * but e.g. (-0.00001).toFixed(0) is '-0'.
+   *
+   * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {dp|rm}'
+   */
+  P.toFixed = function (dp, rm) {
+    if (dp != null) {
+      intCheck(dp, 0, MAX);
+      dp = dp + this.e + 1;
+    }
+    return format(this, dp, rm);
+  };
+
+
+  /*
+   * Return a string representing the value of this BigNumber in fixed-point notation rounded
+   * using rm or ROUNDING_MODE to dp decimal places, and formatted according to the properties
+   * of the FORMAT object (see BigNumber.set).
+   *
+   * FORMAT = {
+   *      decimalSeparator : '.',
+   *      groupSeparator : ',',
+   *      groupSize : 3,
+   *      secondaryGroupSize : 0,
+   *      fractionGroupSeparator : '\xA0',    // non-breaking space
+   *      fractionGroupSize : 0
+   * };
+   *
+   * [dp] {number} Decimal places. Integer, 0 to MAX inclusive.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {dp|rm}'
+   */
+  P.toFormat = function (dp, rm) {
+    var str = this.toFixed(dp, rm);
+
+    if (this.c) {
+      var i,
+        arr = str.split('.'),
+        g1 = +FORMAT.groupSize,
+        g2 = +FORMAT.secondaryGroupSize,
+        groupSeparator = FORMAT.groupSeparator,
+        intPart = arr[0],
+        fractionPart = arr[1],
+        isNeg = this.s < 0,
+        intDigits = isNeg ? intPart.slice(1) : intPart,
+        len = intDigits.length;
+
+      if (g2) i = g1, g1 = g2, g2 = i, len -= i;
+
+      if (g1 > 0 && len > 0) {
+        i = len % g1 || g1;
+        intPart = intDigits.substr(0, i);
+
+        for (; i < len; i += g1) {
+          intPart += groupSeparator + intDigits.substr(i, g1);
+        }
+
+        if (g2 > 0) intPart += groupSeparator + intDigits.slice(i);
+        if (isNeg) intPart = '-' + intPart;
+      }
+
+      str = fractionPart
+       ? intPart + FORMAT.decimalSeparator + ((g2 = +FORMAT.fractionGroupSize)
+        ? fractionPart.replace(new RegExp('\\d{' + g2 + '}\\B', 'g'),
+         '$&' + FORMAT.fractionGroupSeparator)
+        : fractionPart)
+       : intPart;
+    }
+
+    return str;
+  };
+
+
+  /*
+   * Return a string array representing the value of this BigNumber as a simple fraction with
+   * an integer numerator and an integer denominator. The denominator will be a positive
+   * non-zero value less than or equal to the specified maximum denominator. If a maximum
+   * denominator is not specified, the denominator will be the lowest value necessary to
+   * represent the number exactly.
+   *
+   * [md] {number|string|BigNumber} Integer >= 1, or Infinity. The maximum denominator.
+   *
+   * '[BigNumber Error] Argument {not an integer|out of range} : {md}'
+   */
+  P.toFraction = function (md) {
+    var arr, d, d0, d1, d2, e, exp, n, n0, n1, q, s,
+      x = this,
+      xc = x.c;
+
+    if (md != null) {
+      n = new BigNumber(md);
+
+      // Throw if md is less than one or is not an integer, unless it is Infinity.
+      if (!n.isInteger() && (n.c || n.s !== 1) || n.lt(ONE)) {
+        throw Error
+          (bignumberError + 'Argument ' +
+            (n.isInteger() ? 'out of range: ' : 'not an integer: ') + md);
+      }
+    }
+
+    if (!xc) return x.toString();
+
+    d = new BigNumber(ONE);
+    n1 = d0 = new BigNumber(ONE);
+    d1 = n0 = new BigNumber(ONE);
+    s = coeffToString(xc);
+
+    // Determine initial denominator.
+    // d is a power of 10 and the minimum max denominator that specifies the value exactly.
+    e = d.e = s.length - x.e - 1;
+    d.c[0] = POWS_TEN[(exp = e % LOG_BASE) < 0 ? LOG_BASE + exp : exp];
+    md = !md || n.comparedTo(d) > 0 ? (e > 0 ? d : n1) : n;
+
+    exp = MAX_EXP;
+    MAX_EXP = 1 / 0;
+    n = new BigNumber(s);
+
+    // n0 = d1 = 0
+    n0.c[0] = 0;
+
+    for (; ;)  {
+      q = div(n, d, 0, 1);
+      d2 = d0.plus(q.times(d1));
+      if (d2.comparedTo(md) == 1) break;
+      d0 = d1;
+      d1 = d2;
+      n1 = n0.plus(q.times(d2 = n1));
+      n0 = d2;
+      d = n.minus(q.times(d2 = d));
+      n = d2;
+    }
+
+    d2 = div(md.minus(d0), d1, 0, 1);
+    n0 = n0.plus(d2.times(n1));
+    d0 = d0.plus(d2.times(d1));
+    n0.s = n1.s = x.s;
+    e *= 2;
+
+    // Determine which fraction is closer to x, n0/d0 or n1/d1
+    arr = div(n1, d1, e, ROUNDING_MODE).minus(x).abs().comparedTo(
+       div(n0, d0, e, ROUNDING_MODE).minus(x).abs()) < 1
+        ? [n1.toString(), d1.toString()]
+        : [n0.toString(), d0.toString()];
+
+    MAX_EXP = exp;
+    return arr;
+  };
+
+
+  /*
+   * Return the value of this BigNumber converted to a number primitive.
+   */
+  P.toNumber = function () {
+    return +this;
+  };
+
+
+  /*
+   * Return a string representing the value of this BigNumber rounded to sd significant digits
+   * using rounding mode rm or ROUNDING_MODE. If sd is less than the number of digits
+   * necessary to represent the integer part of the value in fixed-point notation, then use
+   * exponential notation.
+   *
+   * [sd] {number} Significant digits. Integer, 1 to MAX inclusive.
+   * [rm] {number} Rounding mode. Integer, 0 to 8 inclusive.
+   *
+   * '[BigNumber Error] Argument {not a primitive number|not an integer|out of range}: {sd|rm}'
+   */
+  P.toPrecision = function (sd, rm) {
+    if (sd != null) intCheck(sd, 1, MAX);
+    return format(this, sd, rm, 2);
+  };
+
+
+  /*
+   * Return a string representing the value of this BigNumber in base b, or base 10 if b is
+   * omitted. If a base is specified, including base 10, round according to DECIMAL_PLACES and
+   * ROUNDING_MODE. If a base is not specified, and this BigNumber has a positive exponent
+   * that is equal to or greater than TO_EXP_POS, or a negative exponent equal to or less than
+   * TO_EXP_NEG, return exponential notation.
+   *
+   * [b] {number} Integer, 2 to ALPHABET.length inclusive.
+   *
+   * '[BigNumber Error] Base {not a primitive number|not an integer|out of range}: {b}'
+   */
+  P.toString = function (b) {
+    var str,
+      n = this,
+      s = n.s,
+      e = n.e;
+
+    // Infinity or NaN?
+    if (e === null) {
+
+      if (s) {
+        str = 'Infinity';
+        if (s < 0) str = '-' + str;
+      } else {
+        str = 'NaN';
+      }
+    } else {
+      str = coeffToString(n.c);
+
+      if (b == null) {
+        str = e <= TO_EXP_NEG || e >= TO_EXP_POS
+         ? toExponential(str, e)
+         : toFixedPoint(str, e, '0');
+      } else {
+        intCheck(b, 2, ALPHABET.length, 'Base');
+        str = convertBase(toFixedPoint(str, e, '0'), 10, b, s, true);
+      }
+
+      if (s < 0 && n.c[0]) str = '-' + str;
+    }
+
+    return str;
+  };
+
+
+  /*
+   * Return as toString, but do not accept a base argument, and include the minus sign for
+   * negative zero.
+   */
+  P.valueOf = P.toJSON = function () {
+    var str,
+      n = this,
+      e = n.e;
+
+    if (e === null) return n.toString();
+
+    str = coeffToString(n.c);
+
+    str = e <= TO_EXP_NEG || e >= TO_EXP_POS
+      ? toExponential(str, e)
+      : toFixedPoint(str, e, '0');
+
+    return n.s < 0 ? '-' + str : str;
+  };
+
+
+  P._isBigNumber = true;
+
+  if (configObject != null) BigNumber.set(configObject);
+
+  return BigNumber;
+}
+
+
+// PRIVATE HELPER FUNCTIONS
+
+
+function bitFloor(n) {
+  var i = n | 0;
+  return n > 0 || n === i ? i : i - 1;
+}
+
+
+// Return a coefficient array as a string of base 10 digits.
+function coeffToString(a) {
+  var s, z,
+    i = 1,
+    j = a.length,
+    r = a[0] + '';
+
+  for (; i < j;) {
+    s = a[i++] + '';
+    z = LOG_BASE - s.length;
+    for (; z--; s = '0' + s);
+    r += s;
+  }
+
+  // Determine trailing zeros.
+  for (j = r.length; r.charCodeAt(--j) === 48;);
+  return r.slice(0, j + 1 || 1);
+}
+
+
+// Compare the value of BigNumbers x and y.
+function compare(x, y) {
+  var a, b,
+    xc = x.c,
+    yc = y.c,
+    i = x.s,
+    j = y.s,
+    k = x.e,
+    l = y.e;
+
+  // Either NaN?
+  if (!i || !j) return null;
+
+  a = xc && !xc[0];
+  b = yc && !yc[0];
+
+  // Either zero?
+  if (a || b) return a ? b ? 0 : -j : i;
+
+  // Signs differ?
+  if (i != j) return i;
+
+  a = i < 0;
+  b = k == l;
+
+  // Either Infinity?
+  if (!xc || !yc) return b ? 0 : !xc ^ a ? 1 : -1;
+
+  // Compare exponents.
+  if (!b) return k > l ^ a ? 1 : -1;
+
+  j = (k = xc.length) < (l = yc.length) ? k : l;
+
+  // Compare digit by digit.
+  for (i = 0; i < j; i++) if (xc[i] != yc[i]) return xc[i] > yc[i] ^ a ? 1 : -1;
+
+  // Compare lengths.
+  return k == l ? 0 : k > l ^ a ? 1 : -1;
+}
+
+
+/*
+ * Check that n is a primitive number, an integer, and in range, otherwise throw.
+ */
+function intCheck(n, min, max, name) {
+  if (n < min || n > max || n !== (n < 0 ? mathceil(n) : mathfloor(n))) {
+    throw Error
+     (bignumberError + (name || 'Argument') + (typeof n == 'number'
+       ? n < min || n > max ? ' out of range: ' : ' not an integer: '
+       : ' not a primitive number: ') + n);
+  }
+}
+
+
+function isArray(obj) {
+  return Object.prototype.toString.call(obj) == '[object Array]';
+}
+
+
+// Assumes finite n.
+function isOdd(n) {
+  var k = n.c.length - 1;
+  return bitFloor(n.e / LOG_BASE) == k && n.c[k] % 2 != 0;
+}
+
+
+function toExponential(str, e) {
+  return (str.length > 1 ? str.charAt(0) + '.' + str.slice(1) : str) +
+   (e < 0 ? 'e' : 'e+') + e;
+}
+
+
+function toFixedPoint(str, e, z) {
+  var len, zs;
+
+  // Negative exponent?
+  if (e < 0) {
+
+    // Prepend zeros.
+    for (zs = z + '.'; ++e; zs += z);
+    str = zs + str;
+
+  // Positive exponent
+  } else {
+    len = str.length;
+
+    // Append zeros.
+    if (++e > len) {
+      for (zs = z, e -= len; --e; zs += z);
+      str += zs;
+    } else if (e < len) {
+      str = str.slice(0, e) + '.' + str.slice(e);
+    }
+  }
+
+  return str;
+}
+
+
+// EXPORTS
+
+
+var BigNumber = clone();
+
+/* harmony default export */ __webpack_exports__["default"] = (BigNumber);
 
 
 /***/ }),
@@ -9385,12 +9838,12 @@ BufferList.prototype.push = function push(buf) {
 /***/ (function(module, exports, __webpack_require__) {
 
 exports.ChangeUser = __webpack_require__(42);
-exports.Handshake = __webpack_require__(65);
-exports.Ping = __webpack_require__(66);
+exports.Handshake = __webpack_require__(67);
+exports.Ping = __webpack_require__(68);
 exports.Query = __webpack_require__(19);
-exports.Quit = __webpack_require__(76);
+exports.Quit = __webpack_require__(78);
 exports.Sequence = __webpack_require__(3);
-exports.Statistics = __webpack_require__(77);
+exports.Statistics = __webpack_require__(79);
 
 
 /***/ }),
@@ -9414,6 +9867,14 @@ function ChangeUser(options, callback) {
   this._currentConfig = options.currentConfig;
 }
 
+ChangeUser.prototype.determinePacket = function determinePacket(firstByte) {
+  switch (firstByte) {
+    case 0xfe: return Packets.AuthSwitchRequestPacket;
+    case 0xff: return Packets.ErrorPacket;
+    default: return undefined;
+  }
+};
+
 ChangeUser.prototype.start = function(handshakeInitializationPacket) {
   var scrambleBuff = handshakeInitializationPacket.scrambleBuff();
   scrambleBuff     = Auth.token(this._password, scrambleBuff);
@@ -9431,6 +9892,24 @@ ChangeUser.prototype.start = function(handshakeInitializationPacket) {
   this._currentConfig.charsetNumber = this._charsetNumber;
 
   this.emit('packet', packet);
+};
+
+ChangeUser.prototype['AuthSwitchRequestPacket'] = function (packet) {
+  var name = packet.authMethodName;
+  var data = Auth.auth(name, packet.authMethodData, {
+    password: this._password
+  });
+
+  if (data !== undefined) {
+    this.emit('packet', new Packets.AuthSwitchResponsePacket({
+      data: data
+    }));
+  } else {
+    var err   = new Error('MySQL is requesting the ' + name + ' authentication method, which is not supported.');
+    err.code  = 'UNSUPPORTED_AUTH_METHOD';
+    err.fatal = true;
+    this.end(err);
+  }
 };
 
 ChangeUser.prototype['ErrorPacket'] = function(packet) {
@@ -10028,12 +10507,11 @@ function OldPasswordPacket(options) {
 }
 
 OldPasswordPacket.prototype.parse = function(parser) {
-  this.scrambleBuff = parser.parseNullTerminatedBuffer();
+  this.scrambleBuff = parser.parsePacketTerminatedBuffer();
 };
 
 OldPasswordPacket.prototype.write = function(writer) {
   writer.writeBuffer(this.scrambleBuff);
-  writer.writeFiller(1);
 };
 
 
@@ -10197,10 +10675,7 @@ function typeCast(field, parser, timeZone, supportBigNumbers, bigNumberStrings, 
 
 function typeMatch(type, list) {
   if (Array.isArray(list)) {
-    for (var i = 0; i < list.length; i++) {
-      if (Types[list[i]] === type) return true;
-    }
-    return false;
+    return list.indexOf(Types[type]) !== -1;
   } else {
     return Boolean(list);
   }
@@ -10293,7 +10768,7 @@ UseOldPasswordPacket.prototype.write = function(writer) {
 /**
  * MySQL error constants
  *
- * Extracted from version 5.7.19
+ * Extracted from version 5.7.21
  *
  * !! Generated by generate-error-constants.js, do not modify by hand !!
  */
@@ -11496,6 +11971,11 @@ exports.ER_WARN_USING_GEOMFROMWKB_TO_SET_SRID_ZERO                              
 exports.ER_WARN_USING_GEOMFROMWKB_TO_SET_SRID                                            = 3196;
 exports.ER_XA_RETRY                                                                      = 3197;
 exports.ER_KEYRING_AWS_UDF_AWS_KMS_ERROR                                                 = 3198;
+exports.ER_BINLOG_UNSAFE_XA                                                              = 3199;
+exports.ER_UDF_ERROR                                                                     = 3200;
+exports.ER_KEYRING_MIGRATION_FAILURE                                                     = 3201;
+exports.ER_KEYRING_ACCESS_DENIED_ERROR                                                   = 3202;
+exports.ER_KEYRING_MIGRATION_STATUS                                                      = 3203;
 
 // Lookup-by-number table
 exports[1]    = 'EE_CANTCREATEFILE';
@@ -12696,10 +13176,60 @@ exports[3195] = 'ER_WARN_USING_GEOMFROMWKB_TO_SET_SRID_ZERO';
 exports[3196] = 'ER_WARN_USING_GEOMFROMWKB_TO_SET_SRID';
 exports[3197] = 'ER_XA_RETRY';
 exports[3198] = 'ER_KEYRING_AWS_UDF_AWS_KMS_ERROR';
+exports[3199] = 'ER_BINLOG_UNSAFE_XA';
+exports[3200] = 'ER_UDF_ERROR';
+exports[3201] = 'ER_KEYRING_MIGRATION_FAILURE';
+exports[3202] = 'ER_KEYRING_ACCESS_DENIED_ERROR';
+exports[3203] = 'ER_KEYRING_MIGRATION_STATUS';
 
 
 /***/ }),
 /* 65 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var Timers = __webpack_require__(66);
+
+module.exports = Timer;
+function Timer(object) {
+  this._object  = object;
+  this._timeout = null;
+}
+
+Timer.prototype.active = function active() {
+  if (this._timeout) {
+    if (this._timeout.refresh) {
+      this._timeout.refresh();
+    } else {
+      Timers.active(this._timeout);
+    }
+  }
+};
+
+Timer.prototype.start = function start(msecs) {
+  this.stop();
+  this._timeout = Timers.setTimeout(this._onTimeout.bind(this), msecs);
+};
+
+Timer.prototype.stop = function stop() {
+  if (this._timeout) {
+    Timers.clearTimeout(this._timeout);
+    this._timeout = null;
+  }
+};
+
+Timer.prototype._onTimeout = function _onTimeout() {
+  return this._object._onTimeout();
+};
+
+
+/***/ }),
+/* 66 */
+/***/ (function(module, exports) {
+
+module.exports = require("timers");
+
+/***/ }),
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Sequence        = __webpack_require__(3);
@@ -12738,26 +13268,19 @@ Handshake.prototype.determinePacket = function determinePacket(firstByte, parser
 };
 
 Handshake.prototype['AuthSwitchRequestPacket'] = function (packet) {
-  switch (packet.authMethodName) {
-    case 'mysql_native_password':
-    case 'mysql_old_password':
-    default:
-  }
+  var name = packet.authMethodName;
+  var data = Auth.auth(name, packet.authMethodData, {
+    password: this._config.password
+  });
 
-  if (packet.authMethodName === 'mysql_native_password') {
-    var challenge = packet.authMethodData.slice(0, 20);
-
+  if (data !== undefined) {
     this.emit('packet', new Packets.AuthSwitchResponsePacket({
-      data: Auth.token(this._config.password, challenge)
+      data: data
     }));
   } else {
-    var err = new Error(
-      'MySQL is requesting the ' + packet.authMethodName + ' authentication method, which is not supported.'
-    );
-
-    err.code = 'UNSUPPORTED_AUTH_METHOD';
+    var err   = new Error('MySQL is requesting the ' + name + ' authentication method, which is not supported.');
+    err.code  = 'UNSUPPORTED_AUTH_METHOD';
     err.fatal = true;
-
     this.end(err);
   }
 };
@@ -12838,7 +13361,7 @@ Handshake.prototype['ErrorPacket'] = function(packet) {
 
 
 /***/ }),
-/* 66 */
+/* 68 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Sequence = __webpack_require__(3);
@@ -12863,7 +13386,7 @@ Ping.prototype.start = function() {
 
 
 /***/ }),
-/* 67 */
+/* 69 */
 /***/ (function(module, exports) {
 
 module.exports = ResultSet;
@@ -12876,7 +13399,7 @@ function ResultSet(resultSetHeaderPacket) {
 
 
 /***/ }),
-/* 68 */
+/* 70 */
 /***/ (function(module, exports) {
 
 // Manually extracted from mysql-5.5.23/include/mysql_com.h
@@ -12921,13 +13444,13 @@ exports.SERVER_PS_OUT_PARAMS = 4096;
 
 
 /***/ }),
-/* 69 */
+/* 71 */
 /***/ (function(module, exports) {
 
 module.exports = require("fs");
 
 /***/ }),
-/* 70 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Stream = __webpack_require__(13);
@@ -12947,12 +13470,12 @@ if (process.env.READABLE_STREAM === 'disable' && Stream) {
   exports.Writable = __webpack_require__(23);
   exports.Duplex = __webpack_require__(5);
   exports.Transform = __webpack_require__(25);
-  exports.PassThrough = __webpack_require__(75);
+  exports.PassThrough = __webpack_require__(77);
 }
 
 
 /***/ }),
-/* 71 */
+/* 73 */
 /***/ (function(module, exports) {
 
 var toString = {}.toString;
@@ -12963,7 +13486,7 @@ module.exports = Array.isArray || function (arr) {
 
 
 /***/ }),
-/* 72 */
+/* 74 */
 /***/ (function(module, exports) {
 
 if (typeof Object.create === 'function') {
@@ -12992,18 +13515,16 @@ if (typeof Object.create === 'function') {
 
 
 /***/ }),
-/* 73 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 
-/*<replacement>*/
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var Buffer = __webpack_require__(1).Buffer;
-/*</replacement>*/
+var util = __webpack_require__(0);
 
 function copyBuffer(src, target, offset) {
   src.copy(target, offset);
@@ -13071,8 +13592,15 @@ module.exports = function () {
   return BufferList;
 }();
 
+if (util && util.inspect && util.inspect.custom) {
+  module.exports.prototype[util.inspect.custom] = function () {
+    var obj = util.inspect({ length: this.length });
+    return this.constructor.name + ' ' + obj;
+  };
+}
+
 /***/ }),
-/* 74 */
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
 
@@ -13084,7 +13612,7 @@ module.exports = __webpack_require__(0).deprecate;
 
 
 /***/ }),
-/* 75 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -13137,7 +13665,7 @@ PassThrough.prototype._transform = function (chunk, encoding, cb) {
 };
 
 /***/ }),
-/* 76 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Sequence = __webpack_require__(3);
@@ -13183,7 +13711,7 @@ Quit.prototype.start = function() {
 
 
 /***/ }),
-/* 77 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Sequence = __webpack_require__(3);
@@ -13219,13 +13747,7 @@ Statistics.prototype.determinePacket = function determinePacket(firstByte) {
 
 
 /***/ }),
-/* 78 */
-/***/ (function(module, exports) {
-
-module.exports = require("timers");
-
-/***/ }),
-/* 79 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var BIT_16            = Math.pow(2, 16);
@@ -13442,14 +13964,14 @@ PacketWriter.prototype._allocate = function _allocate(bytes) {
 
 
 /***/ }),
-/* 80 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(81);
+module.exports = __webpack_require__(82);
 
 
 /***/ }),
-/* 81 */
+/* 82 */
 /***/ (function(module, exports) {
 
 var SqlString  = exports;
@@ -13537,13 +14059,19 @@ SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
   }
 
   var chunkIndex        = 0;
-  var placeholdersRegex = /\?\??/g;
+  var placeholdersRegex = /\?+/g;
   var result            = '';
   var valuesIndex       = 0;
   var match;
 
   while (valuesIndex < values.length && (match = placeholdersRegex.exec(sql))) {
-    var value = match[0] === '??'
+    var len = match[0].length;
+
+    if (len > 2) {
+      continue;
+    }
+
+    var value = len === 2
       ? SqlString.escapeId(values[valuesIndex])
       : SqlString.escape(values[valuesIndex], stringifyObjects, timeZone);
 
@@ -13686,7 +14214,7 @@ function convertTimezone(tz) {
 
 
 /***/ }),
-/* 82 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var inherits   = __webpack_require__(0).inherits;
@@ -13757,12 +14285,12 @@ PoolConnection.prototype._removeFromPool = function _removeFromPool() {
 
 
 /***/ }),
-/* 83 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Pool          = __webpack_require__(27);
 var PoolConfig    = __webpack_require__(28);
-var PoolNamespace = __webpack_require__(84);
+var PoolNamespace = __webpack_require__(85);
 var PoolSelector  = __webpack_require__(29);
 var Util          = __webpack_require__(0);
 var EventEmitter  = __webpack_require__(4).EventEmitter;
@@ -14051,7 +14579,7 @@ function _noop() {}
 
 
 /***/ }),
-/* 84 */
+/* 85 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Connection   = __webpack_require__(8);

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -166,7 +166,11 @@ global.on('onServerResourceStart', (resourcename) => {
         pool = mysql.createPool(config);
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
-        keepAlive();
+
+        if(global.GetConvar('mysql_keep_alive', false)){
+            console.log('[MySQL] Enabling keep alive queries')
+            keepAlive();
+        }
     }
     if (isReady) {
         global.emit('MySQLReady'); // avoid ESX bugs

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -166,8 +166,15 @@ global.on('onServerResourceStart', (resourcename) => {
         pool = mysql.createPool(config);
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
+        keepAlive();
     }
     if (isReady) {
         global.emit('MySQLReady'); // avoid ESX bugs
     }
 });
+
+function keepAlive(){
+    execute({ sql: 'SHOW TABLES', typeCast }, 'keepAlive').then((result) => {
+        setTimeout(keepAlive, 10000);
+    });
+}

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -95,7 +95,7 @@ global.exports('mysql_fetch_scalar', (query, parameters, callback) => {
     const invokingResource = global.GetInvokingResource();
     let sql = prepareQuery(query, parameters);
     execute({ sql, typeCast }, invokingResource).then((result) => {
-        safeInvoke(callback, (result) ? Object.values(result[0])[0] : null);
+        safeInvoke(callback, (result && Array.isArray(result) && result.length > 0) ? Object.values(result[0])[0] : null);
     });
 });
 

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -167,7 +167,7 @@ global.on('onServerResourceStart', (resourcename) => {
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
 
-        if(global.GetConvar('mysql_keep_alive', false) === 'true'){
+        if(global.GetConvar('mysql_keep_alive', 'false') === 'true'){
             console.log('[MySQL] Enabling keep alive queries')
             keepAlive();
         }

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -167,7 +167,7 @@ global.on('onServerResourceStart', (resourcename) => {
         global.emit('onMySQLReady'); // avoid ESX bugs
         isReady = true;
 
-        if(global.GetConvar('mysql_keep_alive', false)){
+        if(global.GetConvar('mysql_keep_alive', false) === 'true'){
             console.log('[MySQL] Enabling keep alive queries')
             keepAlive();
         }


### PR DESCRIPTION
The `result` variable in the callback is in most cases a valid empty array, which results tests as `true` in a statement. Thus, need to test array validity and length above 0.

Should fix issues #62 and #63 