### PR TITLE
Keep alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ server_script '@mysql-async/lib/MySQL.lua'
 
 Add this convar to your server configuration and change the values according to your MySQL installation:
 
-`set mysql_connection_string "server=localhost;uid=mysqluser;password=password;database=fivem"`
+```
+set mysql_connection_string "server=localhost;uid=mysqluser;password=password;database=fivem"
+```
+
+### Keep alive
+In order to enable a keep alive query, add the following convar to your server configuration. This will execute a query on the given interval. By default this is disabled. If enabling, recommended is doing this every 60 seconds. Setting it to `0` will explicitely disable this feature.
+
+```
+set mysql_keep_alive_seconds 60
+``` 
 
 ### Alternatively mysql.js connection string
 

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -167,6 +167,8 @@ function parseConnectingString(connectionString) {
 }
 
 let isReady = false;
+let keepAliveSeconds = 0;
+
 global.on('onServerResourceStart', (resourcename) => {
   if (resourcename === 'mysql-async') {
     // maybe default to addr=localhost;pwd=;database=essentialmode;uid=root
@@ -178,8 +180,22 @@ global.on('onServerResourceStart', (resourcename) => {
     pool = mysql.createPool(config);
     global.emit('onMySQLReady'); // avoid ESX bugs
     isReady = true;
+
+    keepAliveSeconds = global.GetConvarInt('mysql_keep_alive_seconds', 0);
+    if (keepAliveSeconds > 0) {
+      console.log('[MySQL] Enabling keep alive queries');
+      keepAlive();
+    }
   }
   if (isReady) {
     global.emit('MySQLReady'); // avoid ESX bugs
   }
 });
+
+function keepAlive() {
+  if (!keepAliveSeconds || keepAliveSeconds <= 0) return; // Safeguard to stop when disabled
+
+  execute({ sql: 'SHOW TABLES', typeCast }, 'keepAlive').then((result) => {
+    setTimeout(keepAlive, keepAliveSeconds * 1000);
+  });
+}


### PR DESCRIPTION
Option the keep the mysql connection alive by executing a mysql query on a configurable interval. Disabled by default. Can be enabled by setting the interval in seconds in the configuration file (see updated README).

---

I decided to stay with `setTimeout` for now. This is because it guarantees that only after a successful execution, the keeping alive is being continued. If using an interval, there is a risk it keeps building up queries even though they all cannot be executed. This also prevents problems when an user configures it to run every second and for some reason some of the executions take over 1 second. Now it is always in strict order.

If you think that my reasoning is off, let me know and I shall change it.