### PR TITLE
Fix for slowQueryWarningTime not printing correctly

### DIFF
--- a/mysql-async.js
+++ b/mysql-async.js
@@ -14365,7 +14365,7 @@ class Profiler {
       this.addSlowQuery(sql, resource, queryTime);
     }
 
-    if (this.slowQueryWarningTime < queryTime) {
+    if (this.config.slowQueryWarningTime < queryTime) {
       this.logger.error(`[${this.version}] [Slow Query Warning] [${resource}] [${queryTime.toFixed()}ms] ${sql}`);
     }
 


### PR DESCRIPTION
this.slowQueryWarningTime is nil, needs to pull from the config