### PR TITLE
Fixed typo in MySQL.Sync.transaction

### DIFF
--- a/lib/MySQL.lua
+++ b/lib/MySQL.lua
@@ -113,7 +113,7 @@ end
 function MySQL.Sync.transaction(querys, params)
     local res = 0
     local finishedQuery = false
-    exports['mysql-async']:mysql_transaction(query, params, function (result)
+    exports['mysql-async']:mysql_transaction(querys, params, function (result)
         res = result
         finishedQuery = true
     end)


### PR DESCRIPTION
paramter name is querys but transaction itself was called using query, changed them to both be querys.