### PR TITLE
Add 'MySQL.getConfig' method

### DIFF
--- a/lib/MySQL.lua
+++ b/lib/MySQL.lua
@@ -214,15 +214,26 @@ function MySQL.Async.transaction(querys, params, func)
     return exports['mysql-async']:mysql_transaction(querys, params, func)
 end
 
-function MySQL.ready (callback)
+---
+-- Get the config object
+--
+-- @return table config
+--
+function MySQL.getConfig()
+    return exports['mysql-async']:get_config()
+end
+
+function MySQL.ready(callback)
     Citizen.CreateThread(function ()
         -- add some more error handling
         while GetResourceState('mysql-async') ~= 'started' do
             Citizen.Wait(0)
         end
+            
         while not exports['mysql-async']:is_ready() do
             Citizen.Wait(0)
         end
+            
         callback()
     end)
 end

--- a/mysql-async.js
+++ b/mysql-async.js
@@ -16263,6 +16263,9 @@ global.exports('mysql_store', (query, callback) => {
   server_server.logger.info(`[${invokingResource}] Stored [${storageId}] : ${query}`);
   utility_safeInvoke(callback, storageId);
 });
+global.exports('get_config', () => {
+  return server_config;
+});
 RegisterCommand('mysql:debug', () => {
   let trace = false;
 


### PR DESCRIPTION
Added the `MySQL.getConfig` method, allowing us to retrieve the current server_config object.  
More convenient then having to parse the `mysql_connection_string` convar ourselves, and avoids any conflicts if the convar is not set.